### PR TITLE
Remove reference to window in cql patient JS

### DIFF
--- a/app/assets/javascripts/cqlpatient.js.coffee
+++ b/app/assets/javascripts/cqlpatient.js.coffee
@@ -57,7 +57,7 @@ class CQL_QDM.CQLPatient
             classname = CQL_QDM.OIDMap.oidToClassName(dc)
           unless datatypes[classname]?
             datatypes[classname] = []
-          cql_dc = new window['CQL_QDM'][classname](dc)
+          cql_dc = new CQL_QDM[classname](dc)
           cql_dc['bonnie_type'] = type
           datatypes[classname].push cql_dc
     datatypes


### PR DESCRIPTION
The CQL_QDM variable is available in the global namespace (ie window) in development, but is scoped differently when precompiling assets for production; this change should allow production to work correctly; I've tested it in development.