### PR TITLE
DiagnosticStudyPerformed _facilityLocation initialization fix

### DIFF
--- a/app/assets/javascripts/datatypes/diagnosticstudy.js.coffee
+++ b/app/assets/javascripts/datatypes/diagnosticstudy.js.coffee
@@ -76,7 +76,7 @@ class CQL_QDM.DiagnosticStudyPerformed extends CQL_QDM.QDMDatatype
   constructor: (@entry) ->
     super @entry
     @_authorDatetime = if @entry.negationReason then CQL_QDM.Helpers.convertDateTime(@entry.start_time) else null
-    @_facilityLocation = @entry.facility_location
+    @_facilityLocation = @entry.facility?.code
     @_method = @entry.method
     @_negationRationale = @entry.negationReason
     @_radiationDosage = @entry.radiation_dose


### PR DESCRIPTION
Made facility location parsing consistent for `DiagnosticStudyPerformed` to the rest of the derived classes of `QDMDatatype`.

I have tested this using the debugger loading and comparing to other `QDMDatatype` but the 167 measure has errors unrelated to this change: http://tiny.mitre.org/7FC6 (internal sharepoint site).

I have a couple observations that we might want to address in a separate pull request:
1) There is a lot of shared code among the `cql_qdm_patientapi/app/assets/javascripts/datatypes`
2) Tests. This module is not not tested at all by automated unit tests.