### PR TITLE
Add null check in calculateAgeAt

### DIFF
--- a/vendor/assets/javascripts/cql4browsers.js
+++ b/vendor/assets/javascripts/cql4browsers.js
@@ -2566,14 +2566,18 @@
       var args, date1, date2;
       args = this.execArgs(ctx);
       // AgeAt should not care about the anything less than a day
-      date1 = args[0];
-      date1.hour = 0;
-      date1.minute = 0;
-      date1.second = 0;
-      date1.millisecond = 0;
-      date1 = date1.toJSDate(true);
-      date2 = args[1].toJSDate(true);
-      return calculateAge(date1, date2, this.precision);
+      if ( args[0] && args[1] ){
+        date1 = args[0];
+        date1.hour = 0;
+        date1.minute = 0;
+        date1.second = 0;
+        date1.millisecond = 0;
+        date1 = date1.toJSDate(true);
+        date2 = args[1].toJSDate(true);
+        return calculateAge(date1, date2, this.precision);
+      }else{
+        return null
+      }
     };
 
     return CalculateAgeAt;


### PR DESCRIPTION
This addresses the bug in external ticket 245 https://oncprojectracking.healthit.gov/support/projects/BONNIE/issues/BONNIE-245?filter=allopenissues 

NOTE this measure also has a CQL error, you must remove context population from cql and regenerate ELM.