### PR TITLE
BONNIE-633 Add null check

### DIFF
--- a/vendor/assets/javascripts/cql4browsers.js
+++ b/vendor/assets/javascripts/cql4browsers.js
@@ -2485,6 +2485,9 @@
 
     InValueSet.prototype.exec = function(ctx) {
       var code, valueset;
+      if (this.code == null || this.valueset == null) {
+        return false
+      }
       code = this.code.exec(ctx);
       valueset = this.valueset.exec(ctx);
       if ((code != null) && (valueset != null)) {


### PR DESCRIPTION
When QueryLetRef elements are incorporated into an InValueSet element, their code is set to null.
When the code is later called, this results in a null pointer exception.