### PR TITLE
modified 'result' code to appropriately dereference the result object…

### DIFF
--- a/app/assets/javascripts/datatypes/assessment.js.coffee
+++ b/app/assets/javascripts/datatypes/assessment.js.coffee
@@ -56,8 +56,8 @@ class CQL_QDM.AssessmentPerformed extends CQL_QDM.QDMDatatype
   result: ->
     if @_result
       if @_result.codes?
-        code_system = @_result.codes[Object.keys(@_result.codes)[0]]
-        code = @_result.codes[code_system]
+        code_system = Object.keys(@_result.codes)[0]
+        code = @_result.codes[code_system][0]
         new cql.Code(code, code_system)
       # A PhysicalQuantity with unit UnixTime is a TimeStamp, set in bonnie /lib/measures/patient_builder.rb
       else if @_result.units == "UnixTime"
@@ -137,8 +137,8 @@ class CQL_QDM.AssessmentRecommended extends CQL_QDM.QDMDatatype
   result: ->
     if @_result
       if @_result.codes?
-        code_system = @_result.codes[Object.keys(@_result.codes)[0]]
-        code = @_result.codes[code_system]
+        code_system = Object.keys(@_result.codes)[0]
+        code = @_result.codes[code_system][0]
         new cql.Code(code, code_system)
       # Check that the scalar portion is a number and the units are a non-zero length string.
       else if !isNaN(parseFloat(@_result.scalar)) && @_result.units.length > 0

--- a/app/assets/javascripts/datatypes/diagnosticstudy.js.coffee
+++ b/app/assets/javascripts/datatypes/diagnosticstudy.js.coffee
@@ -153,8 +153,8 @@ class CQL_QDM.DiagnosticStudyPerformed extends CQL_QDM.QDMDatatype
   result: ->
     if @_result
       if @_result.codes?
-        code_system = @_result.codes[Object.keys(@_result.codes)[0]]
-        code = @_result.codes[code_system]
+        code_system = Object.keys(@_result.codes)[0]
+        code = @_result.codes[code_system][0]
         new cql.Code(code, code_system)
       # Check that the scalar portion is a number and the units are a non-zero length string.
       else if !isNaN(parseFloat(@_result.scalar)) && @_result.units.length > 0

--- a/app/assets/javascripts/datatypes/intervention.js.coffee
+++ b/app/assets/javascripts/datatypes/intervention.js.coffee
@@ -96,8 +96,8 @@ class CQL_QDM.InterventionPerformed extends CQL_QDM.QDMDatatype
   result: ->
     if @_result
       if @_result.codes?
-        code_system = @_result.codes[Object.keys(@_result.codes)[0]]
-        code = @_result.codes[code_system]
+        code_system = Object.keys(@_result.codes)[0]
+        code = @_result.codes[code_system][0]
         new cql.Code(code, code_system)
       # Check that the scalar portion is a number and the units are a non-zero length string.
       else if !isNaN(parseFloat(@_result.scalar)) && @_result.units.length > 0

--- a/app/assets/javascripts/datatypes/laboratorytest.js.coffee
+++ b/app/assets/javascripts/datatypes/laboratorytest.js.coffee
@@ -136,8 +136,8 @@ class CQL_QDM.LaboratoryTestPerformed extends CQL_QDM.QDMDatatype
   result: ->
     if @_result
       if @_result.codes?
-        code_system = @_result.codes[Object.keys(@_result.codes)[0]]
-        code = @_result.codes[code_system]
+        code_system = Object.keys(@_result.codes)[0]
+        code = @_result.codes[code_system][0]
         new cql.Code(code, code_system)
       # Check that the scalar portion is a number and the units are a non-zero length string.
       else if !isNaN(parseFloat(@_result.scalar)) && @_result.units.length > 0

--- a/app/assets/javascripts/datatypes/physicalexam.js.coffee
+++ b/app/assets/javascripts/datatypes/physicalexam.js.coffee
@@ -125,8 +125,8 @@ class CQL_QDM.PhysicalExamPerformed extends CQL_QDM.QDMDatatype
   result: ->
     if @_result
       if @_result.codes?
-        code_system = @_result.codes[Object.keys(@_result.codes)[0]]
-        code = @_result.codes[code_system]
+        code_system = Object.keys(@_result.codes)[0]
+        code = @_result.codes[code_system][0]
         new cql.Code(code, code_system)
       # Check that the scalar portion is a number and the units are a non-zero length string.
       else if !isNaN(parseFloat(@_result.scalar)) && @_result.units.length > 0

--- a/app/assets/javascripts/datatypes/procedure.js.coffee
+++ b/app/assets/javascripts/datatypes/procedure.js.coffee
@@ -178,8 +178,8 @@ class CQL_QDM.ProcedurePerformed extends CQL_QDM.QDMDatatype
   result: ->
     if @_result
       if @_result.codes?
-        code_system = @_result.codes[Object.keys(@_result.codes)[0]]
-        code = @_result.codes[code_system]
+        code_system = Object.keys(@_result.codes)[0]
+        code = @_result.codes[code_system][0]
         new cql.Code(code, code_system)
       # Check that the scalar portion is a number and the units are a non-zero length string.
       else if !isNaN(parseFloat(@_result.scalar)) && @_result.units.length > 0


### PR DESCRIPTION
… to fill the code. See external BONNIE-300 to see an example where this change is necessary.

JIRA ticket: https://jira.mitre.org/browse/BONNIE-753

JIRA test to be created.

See attached measure to test. Previously, impossible to get "Newborn Hearing Screening Left" and "Newborn Hearing Screening Right" to calculate. They now calculate with appropriate inputs.
[EHDI1a_v5_2_Artifacts 2.zip](https://github.com/projecttacoma/cql_qdm_patientapi/files/1139790/EHDI1a_v5_2_Artifacts.2.zip)
