### PR TITLE
Dealing with unitless Result Quantities

### DIFF
--- a/app/assets/javascripts/datatypes/assessment.js.coffee
+++ b/app/assets/javascripts/datatypes/assessment.js.coffee
@@ -54,19 +54,7 @@ class CQL_QDM.AssessmentPerformed extends CQL_QDM.QDMDatatype
   @returns {Code|Quantity|Date}
   ###
   result: ->
-    if @_result
-      if @_result.codes?
-        code_system = Object.keys(@_result.codes)[0]
-        code = @_result.codes[code_system][0]
-        new cql.Code(code, code_system)
-      # A PhysicalQuantity with unit UnixTime is a TimeStamp, set in bonnie /lib/measures/patient_builder.rb
-      else if @_result.units == "UnixTime"
-        CQL_QDM.Helpers.convertDateTime(@_result.scalar)
-      # Check that the scalar portion is a number and the units are a non-zero length string.
-      else if !isNaN(parseFloat(@_result.scalar)) && @_result.units.length > 0
-        new cql.Quantity({unit: @_result.units, value: @_result.scalar})
-    else
-      null
+    CQL_QDM.Helpers.formatResult(@_result)
 
   ###
   @returns {Array}
@@ -135,13 +123,4 @@ class CQL_QDM.AssessmentRecommended extends CQL_QDM.QDMDatatype
   @returns {Code|Quantity}
   ###
   result: ->
-    if @_result
-      if @_result.codes?
-        code_system = Object.keys(@_result.codes)[0]
-        code = @_result.codes[code_system][0]
-        new cql.Code(code, code_system)
-      # Check that the scalar portion is a number and the units are a non-zero length string.
-      else if !isNaN(parseFloat(@_result.scalar)) && @_result.units.length > 0
-        new cql.Quantity({unit: @_result.units, value: @_result.scalar})
-    else
-      null
+    CQL_QDM.Helpers.formatResult(@_result)

--- a/app/assets/javascripts/datatypes/assessment.js.coffee
+++ b/app/assets/javascripts/datatypes/assessment.js.coffee
@@ -54,7 +54,12 @@ class CQL_QDM.AssessmentPerformed extends CQL_QDM.QDMDatatype
   @returns {Code|Quantity|Date}
   ###
   result: ->
-    CQL_QDM.Helpers.formatResult(@_result)
+    if @_result
+      # A PhysicalQuantity with unit UnixTime is a TimeStamp, set in bonnie /lib/measures/patient_builder.rb
+      if @_result.units == 'UnixTime'
+        CQL_QDM.Helpers.convertDateTime(@_result.scalar)
+      else
+        CQL_QDM.Helpers.formatResult(@_result)
 
   ###
   @returns {Array}

--- a/app/assets/javascripts/datatypes/diagnosticstudy.js.coffee
+++ b/app/assets/javascripts/datatypes/diagnosticstudy.js.coffee
@@ -151,16 +151,7 @@ class CQL_QDM.DiagnosticStudyPerformed extends CQL_QDM.QDMDatatype
   @returns {Code|Quantity}
   ###
   result: ->
-    if @_result
-      if @_result.codes?
-        code_system = Object.keys(@_result.codes)[0]
-        code = @_result.codes[code_system][0]
-        new cql.Code(code, code_system)
-      # Check that the scalar portion is a number and the units are a non-zero length string.
-      else if !isNaN(parseFloat(@_result.scalar)) && @_result.units.length > 0
-        new cql.Quantity({unit: @_result.units, value: @_result.scalar})
-    else
-      null
+    CQL_QDM.Helpers.formatResult(@_result)
 
   ###
   @returns {Date}

--- a/app/assets/javascripts/datatypes/intervention.js.coffee
+++ b/app/assets/javascripts/datatypes/intervention.js.coffee
@@ -94,16 +94,7 @@ class CQL_QDM.InterventionPerformed extends CQL_QDM.QDMDatatype
   @returns {Code|Quantity}
   ###
   result: ->
-    if @_result
-      if @_result.codes?
-        code_system = Object.keys(@_result.codes)[0]
-        code = @_result.codes[code_system][0]
-        new cql.Code(code, code_system)
-      # Check that the scalar portion is a number and the units are a non-zero length string.
-      else if !isNaN(parseFloat(@_result.scalar)) && @_result.units.length > 0
-        new cql.Quantity({unit: @_result.units, value: @_result.scalar})
-    else
-      null
+    CQL_QDM.Helpers.formatResult(@_result)
 
   ###
   @returns {Code}

--- a/app/assets/javascripts/datatypes/laboratorytest.js.coffee
+++ b/app/assets/javascripts/datatypes/laboratorytest.js.coffee
@@ -134,16 +134,7 @@ class CQL_QDM.LaboratoryTestPerformed extends CQL_QDM.QDMDatatype
   @returns {Code|Quantity}
   ###
   result: ->
-    if @_result
-      if @_result.codes?
-        code_system = Object.keys(@_result.codes)[0]
-        code = @_result.codes[code_system][0]
-        new cql.Code(code, code_system)
-      # Check that the scalar portion is a number and the units are a non-zero length string.
-      else if !isNaN(parseFloat(@_result.scalar)) && @_result.units.length > 0
-        new cql.Quantity({unit: @_result.units, value: @_result.scalar})
-    else
-      null
+    CQL_QDM.Helpers.formatResult(@_result)
 
   ###
   @returns {Date}

--- a/app/assets/javascripts/datatypes/physicalexam.js.coffee
+++ b/app/assets/javascripts/datatypes/physicalexam.js.coffee
@@ -123,16 +123,7 @@ class CQL_QDM.PhysicalExamPerformed extends CQL_QDM.QDMDatatype
   @returns {Code|Quantity}
   ###
   result: ->
-    if @_result
-      if @_result.codes?
-        code_system = Object.keys(@_result.codes)[0]
-        code = @_result.codes[code_system][0]
-        new cql.Code(code, code_system)
-      # Check that the scalar portion is a number and the units are a non-zero length string.
-      else if !isNaN(parseFloat(@_result.scalar)) && @_result.units.length > 0
-        new cql.Quantity({unit: @_result.units, value: @_result.scalar})
-    else
-      null
+    CQL_QDM.Helpers.formatResult(@_result)
 
 
 ###

--- a/app/assets/javascripts/datatypes/procedure.js.coffee
+++ b/app/assets/javascripts/datatypes/procedure.js.coffee
@@ -176,16 +176,7 @@ class CQL_QDM.ProcedurePerformed extends CQL_QDM.QDMDatatype
   @returns {Code|Quantity}
   ###
   result: ->
-    if @_result
-      if @_result.codes?
-        code_system = Object.keys(@_result.codes)[0]
-        code = @_result.codes[code_system][0]
-        new cql.Code(code, code_system)
-      # Check that the scalar portion is a number and the units are a non-zero length string.
-      else if !isNaN(parseFloat(@_result.scalar)) && @_result.units.length > 0
-        new cql.Quantity({unit: @_result.units, value: @_result.scalar})
-    else
-      null
+    CQL_QDM.Helpers.formatResult(@_result)
 
   ###
   @returns {Code}

--- a/app/assets/javascripts/utils/helpers.js.coffee
+++ b/app/assets/javascripts/utils/helpers.js.coffee
@@ -47,13 +47,11 @@ class CQL_QDM.Helpers
         code_system = Object.keys(input.codes)[0]
         code = input.codes[code_system][0]
         new cql.Code(code, code_system)
-      # A PhysicalQuantity with unit UnixTime is a TimeStamp, set in bonnie /lib/measures/patient_builder.rb
-      else if input.units == 'UnixTime'
-        CQL_QDM.Helpers.convertDateTime(input.scalar)
       # Check that the scalar portion is a number and the units are a non-zero length string.
-      else if !isNaN(parseFloat(input.scalar)) && input.units.length > 0
-        new cql.Quantity({unit: cleansedUnit , value: input.scalar})
-      else if !isNaN(parseFloat(input.scalar)) && input.units.length == 0
-        new cql.Quantity({value: input.scalar})
+      else if (input.scalar.match(/^[-+]?[0-9]*\.?[0-9]+$/) != null) 
+        if input.units.length > 0
+          new cql.Quantity({unit: input.units , value: parseFloat(input.scalar)})
+        else
+          parseFloat(input.scalar)
     else
       null

--- a/app/assets/javascripts/utils/helpers.js.coffee
+++ b/app/assets/javascripts/utils/helpers.js.coffee
@@ -30,14 +30,17 @@ class CQL_QDM.Helpers
   @infinityDateTime: ->
     @convertDateTime('12/31/2999 12:59 PM')
 
-  
   ###
   For DateTime values makes sure value meets the CQL standard.
   For scalar values:
     - First checks that the value component is numeric
     - Second for the unit component attempts to clean up freetext
       to match a standard version.
+  
+  @param {Result} input - the result object to be parsed into a Quantity
+  @returns cql.Quantity
   ###
+
   @formatResult: (input) ->
     if input
       if input.codes?
@@ -67,6 +70,9 @@ class CQL_QDM.Helpers
 
   ###
   Take units provided and see if they can be matched to a standard version.
+
+  @param {String} unit - The unit to validate
+  @returns {String}
   ###
   @cleanTimeUnit: (unit) ->
     if time_units[unit] then time_units[unit] else unit

--- a/app/assets/javascripts/utils/helpers.js.coffee
+++ b/app/assets/javascripts/utils/helpers.js.coffee
@@ -52,27 +52,8 @@ class CQL_QDM.Helpers
         CQL_QDM.Helpers.convertDateTime(input.scalar)
       # Check that the scalar portion is a number and the units are a non-zero length string.
       else if !isNaN(parseFloat(input.scalar)) && input.units.length > 0
-        cleansedUnit = @cleanTimeUnit(input.units)
         new cql.Quantity({unit: cleansedUnit , value: input.scalar})
+      else if !isNaN(parseFloat(input.scalar)) && input.units.length == 0
+        new cql.Quantity({value: input.scalar})
     else
       null
-  ###
-  Used to try and convert freetext time units to CQL standard units.
-  ###
-  time_units = {'years': 'year', 'yr': 'year', 'yrs': 'year'
-    , 'months': 'month', 'month': 'month'
-    , 'weeks': 'week', 'week': 'week', 'wk': 'week', 'wks': 'week'
-    , 'days': 'day', 'day': 'day', 'd': 'day'
-    , 'hours': 'h', 'hour': 'hour', 'hr': 'hour', 'hrs': 'hour'
-    , 'minutes': 'min', 'minute': 'minute', 'min': 'minute'
-    , 'seconds': 'second', 'second': 'second', 'sec': 'second'
-    , 'milliseconds': 'millisecond', 'millisecond': 'millisecond', 'ms': 'millisecond'}
-
-  ###
-  Take units provided and see if they can be matched to a standard version.
-
-  @param {String} unit - The unit to validate
-  @returns {String}
-  ###
-  @cleanTimeUnit: (unit) ->
-    if time_units[unit] then time_units[unit] else unit

--- a/app/assets/javascripts/utils/helpers.js.coffee
+++ b/app/assets/javascripts/utils/helpers.js.coffee
@@ -29,3 +29,44 @@ class CQL_QDM.Helpers
   ###
   @infinityDateTime: ->
     @convertDateTime('12/31/2999 12:59 PM')
+
+  
+  ###
+  For DateTime values makes sure value meets the CQL standard.
+  For scalar values:
+    - First checks that the value component is numeric
+    - Second for the unit component attempts to clean up freetext
+      to match a standard version.
+  ###
+  @formatResult: (input) ->
+    if input
+      if input.codes?
+        code_system = input.codes[Object.keys(input.codes)[0]]
+        code = input.codes[code_system]
+        new cql.Code(code, code_system)
+      # A PhysicalQuantity with unit UnixTime is a TimeStamp, set in bonnie /lib/measures/patient_builder.rb
+      else if input.units == 'UnixTime'
+        CQL_QDM.Helpers.convertDateTime(input.scalar)
+      # Check that the scalar portion is a number and the units are a non-zero length string.
+      else if !isNaN(parseFloat(input.scalar)) && input.units.length > 0
+        cleansedUnit = @cleanTimeUnit(input.units)
+        new cql.Quantity({unit: cleansedUnit , value: input.scalar})
+    else
+      null
+  ###
+  Used to try and convert freetext time units to CQL standard units.
+  ###
+  time_units = {'years': 'year', 'yr': 'year', 'yrs': 'year'
+    , 'months': 'month', 'month': 'month'
+    , 'weeks': 'week', 'week': 'week', 'wk': 'week', 'wks': 'week'
+    , 'days': 'day', 'day': 'day', 'd': 'day'
+    , 'hours': 'h', 'hour': 'hour', 'hr': 'hour', 'hrs': 'hour'
+    , 'minutes': 'min', 'minute': 'minute', 'min': 'minute'
+    , 'seconds': 'second', 'second': 'second', 'sec': 'second'
+    , 'milliseconds': 'millisecond', 'millisecond': 'millisecond', 'ms': 'millisecond'}
+
+  ###
+  Take units provided and see if they can be matched to a standard version.
+  ###
+  @cleanTimeUnit: (unit) ->
+    if time_units[unit] then time_units[unit] else unit

--- a/app/assets/javascripts/utils/helpers.js.coffee
+++ b/app/assets/javascripts/utils/helpers.js.coffee
@@ -44,8 +44,8 @@ class CQL_QDM.Helpers
   @formatResult: (input) ->
     if input
       if input.codes?
-        code_system = input.codes[Object.keys(input.codes)[0]]
-        code = input.codes[code_system]
+        code_system = Object.keys(input.codes)[0]
+        code = input.codes[code_system][0]
         new cql.Code(code, code_system)
       # A PhysicalQuantity with unit UnixTime is a TimeStamp, set in bonnie /lib/measures/patient_builder.rb
       else if input.units == 'UnixTime'


### PR DESCRIPTION
This change does two things:

1. It pulls together all of the result formattings from the various datatypes into a central location.
2. Formats a result without a unit (like a Assessment Item test score) as a Quantity (value only, no units)

