### PR TITLE
Adjusted the way datatypes are extracted from patient records to account for slashes in the names

### DIFF
--- a/app/assets/javascripts/cqlpatient.js.coffee
+++ b/app/assets/javascripts/cqlpatient.js.coffee
@@ -184,7 +184,7 @@ class CQL_QDM.CQLPatient
           # e.g. "Encounter, Performed: Face-to-Face Interaction" becomes
           # EncounterPerformed
           classname = dc.description.substr(0, dc.description.indexOf(':'))
-          classname = classname.replace(/,/g, '')
+          classname = classname.replace(/,/g, '').replace(/\//g, '')
           classname = classname.replace(/ /g, '')
           unless data_types[classname]?
             data_types[classname] = []


### PR DESCRIPTION
Adjusted the way datatypes are extracted from patient records to account for slashes in the names.

- Look in the ONC JIRA issue 288 for details:
  https://oncprojectracking.healthit.gov/support/browse/BONNIE-288
- This change replaces missing OIDs as specified in V3 IG CQL Based HQMF R1 STU2, Volume 3

Related to:
https://github.com/projectcypress/health-data-standards/pull/511
https://github.com/projecttacoma/bonnie/pull/771