### PR TITLE
Adds support for querying single item sources

### DIFF
--- a/vendor/assets/javascripts/cql4browsers.js
+++ b/vendor/assets/javascripts/cql4browsers.js
@@ -5498,7 +5498,9 @@
 
     With.prototype.exec = function(ctx) {
       var childCtx, rec, records, returns;
-      records = this.expression.execute(ctx) || [];
+      records = this.expression.execute(ctx);
+      this.isList = typeIsArray(records);
+      records = this.isList ? records : [records];
       returns = (function() {
         var i, len, results;
         results = [];
@@ -5752,7 +5754,11 @@
       if ((ref2 = this.sortClause) != null) {
         ref2.sort(returnedValues);
       }
-      return returnedValues;
+      if (this.sources.returnsList()) {
+        return returnedValues;
+      } else {
+        return returnedValues[0];
+      }
     };
 
     return Query;
@@ -5791,6 +5797,7 @@
       this.sources = sources;
       this.alias = this.sources[0].alias;
       this.expression = this.sources[0].expression;
+      this.isList = true;
       if (this.sources.length > 1) {
         this.rest = new MultiSource(this.sources.slice(1));
       }
@@ -5805,9 +5812,15 @@
       return a;
     };
 
+    MultiSource.prototype.returnsList = function() {
+      return this.isList || (this.rest && this.rest.returnsList());
+    };
+
     MultiSource.prototype.forEach = function(ctx, func) {
       var i, len, rctx, rec, records, results;
-      records = this.expression.execute(ctx) || [];
+      records = this.expression.execute(ctx);
+      this.isList = typeIsArray(records);
+      records = this.isList ? records : [records];
       results = [];
       for (i = 0, len = records.length; i < len; i++) {
         rec = records[i];


### PR DESCRIPTION
Previously you could only query lists.  This update to cql4browsers.js adds support for querying a single item.  Relates to BONNIE-307.  Test at internal BONNIE-825.