### PR TITLE
Removed Radiation Dose and Radiation Duration per QDM 5.3

### DIFF
--- a/app/assets/javascripts/datatypes/diagnosticstudy.js.coffee
+++ b/app/assets/javascripts/datatypes/diagnosticstudy.js.coffee
@@ -24,8 +24,6 @@ class CQL_QDM.DiagnosticStudyOrder extends CQL_QDM.QDMDatatype
     @_authorDatetime = CQL_QDM.Helpers.convertDateTime(@entry.start_time)
     @_method = @entry.method
     @_negationRationale = @entry.negationReason
-    @_radiationDosage = @entry.radiation_dose
-    @_radiationDuration = @entry.radiation_duration
     @_reason = @entry.reason
 
   ###
@@ -45,18 +43,6 @@ class CQL_QDM.DiagnosticStudyOrder extends CQL_QDM.QDMDatatype
   ###
   negationRationale: ->
     new cql.Code(@_negationRationale?.code, @_negationRationale?.code_system)
-
-  ###
-  @returns {Quantity}
-  ###
-  radiationDosage: ->
-    new cql.Quantity({unit: @_radiationDosage['unit'], value: @_radiationDosage['value']})
-
-  ###
-  @returns {Quantity}
-  ###
-  radiationDuration: ->
-    new cql.Quantity({unit: @_radiationDuration['unit'], value: @_radiationDuration['value']})
 
   ###
   @returns {Code}
@@ -80,8 +66,6 @@ class CQL_QDM.DiagnosticStudyPerformed extends CQL_QDM.QDMDatatype
     @_facilityLocation = @entry.facility?.code
     @_method = @entry.method
     @_negationRationale = @entry.negationReason
-    @_radiationDosage = @entry.radiation_dose
-    @_radiationDuration = @entry.radiation_duration
     @_reason = @entry.reason
     if @entry.values? && @entry.values.length > 0
       @_result = @entry.values?[0]
@@ -120,18 +104,6 @@ class CQL_QDM.DiagnosticStudyPerformed extends CQL_QDM.QDMDatatype
   ###
   negationRationale: ->
     new cql.Code(@_negationRationale?.code, @_negationRationale?.code_system)
-
-  ###
-  @returns {Quantity}
-  ###
-  radiationDosage: ->
-    new cql.Quantity({unit: @_radiationDosage['unit'], value: @_radiationDosage['value']})
-
-  ###
-  @returns {Quantity}
-  ###
-  radiationDuration: ->
-    new cql.Quantity({unit: @_radiationDuration['unit'], value: @_radiationDuration['value']})
 
   ###
   @returns {Code}
@@ -192,8 +164,6 @@ class CQL_QDM.DiagnosticStudyRecommended extends CQL_QDM.QDMDatatype
     @_authorDatetime = CQL_QDM.Helpers.convertDateTime(@entry.start_time)
     @_method = @entry.method
     @_negationRationale = @entry.negationReason
-    @_radiationDosage = @entry.radiation_dose
-    @_radiationDuration = @entry.radiation_duration
 
   ###
   @returns {Date}
@@ -213,14 +183,3 @@ class CQL_QDM.DiagnosticStudyRecommended extends CQL_QDM.QDMDatatype
   negationRationale: ->
     new cql.Code(@_negationRationale?.code, @_negationRationale?.code_system)
 
-  ###
-  @returns {Quantity}
-  ###
-  radiationDosage: ->
-    new cql.Quantity({unit: @_radiationDosage['unit'], value: @_radiationDosage['value']})
-
-  ###
-  @returns {Quantity}
-  ###
-  radiationDuration: ->
-    new cql.Quantity({unit: @_radiationDuration['unit'], value: @_radiationDuration['value']})

--- a/app/assets/javascripts/datatypes/procedure.js.coffee
+++ b/app/assets/javascripts/datatypes/procedure.js.coffee
@@ -20,7 +20,6 @@ class CQL_QDM.ProcedureOrder extends CQL_QDM.QDMDatatype
     @_method = @entry.method
     @_negationRationale = @entry.negationReason
     @_ordinality = @entry.ordinality
-    @_radiationDuration = @entry.radiation_duration
     @_reason = @entry.reason
 
   ###
@@ -60,12 +59,6 @@ class CQL_QDM.ProcedureOrder extends CQL_QDM.QDMDatatype
     new cql.Code(@_ordinality?.code, @_ordinality?.code_system)
 
   ###
-  @returns {Quantity}
-  ###
-  radiationDuration: ->
-    new cql.Quantity({unit: @_radiationDuration['unit'], value: @_radiationDuration['value']})
-
-  ###
   @returns {Code}
   ###
   reason: ->
@@ -90,8 +83,6 @@ class CQL_QDM.ProcedurePerformed extends CQL_QDM.QDMDatatype
     @_method = @entry.method
     @_negationRationale = @entry.negationReason
     @_ordinality = @entry.ordinality
-    @_radiationDosage = @entry.radiation_dose
-    @_radiationDuration = @entry.radiation_duration
     @_reason = @entry.reason
     @_relevantPeriodLow = CQL_QDM.Helpers.convertDateTime(@entry.start_time)
     if @entry.end_time
@@ -145,18 +136,6 @@ class CQL_QDM.ProcedurePerformed extends CQL_QDM.QDMDatatype
   ###
   ordinality: ->
     new cql.Code(@_ordinality?.code, @_ordinality?.code_system)
-
-  ###
-  @returns {Quantity}
-  ###
-  radiationDosage: ->
-    new cql.Quantity({unit: @_radiationDosage['unit'], value: @_radiationDosage['value']})
-
-  ###
-  @returns {Quantity}
-  ###
-  radiationDuration: ->
-    new cql.Quantity({unit: @_radiationDuration['unit'], value: @_radiationDuration['value']})
 
   ###
   @returns {Code}


### PR DESCRIPTION
Text from QDM 5.3 spec:

> Removed Radiation Dose and Radiation Duration attributes as they have not been used and the use case is not defined. The concepts can be expressed using Assessment, Performed or Diagnostic Test, Performed.

Bonnie JIRA: https://jira.mitre.org/browse/BONNIE-934
Tests: searched existing measures these fields are not used.

Only current measures I found that have anything to do with the word "radiation" at all:
- [cqltest157_v5_0_artifacts.zip](https://github.com/projecttacoma/cql_qdm_patientapi/files/1195209/cqltest157_v5_0_artifacts.zip)
- [EP_EC_CMS157v6_NQF0384_ONC_PainQuantified.zip](https://github.com/projecttacoma/cql_qdm_patientapi/files/1195210/EP_EC_CMS157v6_NQF0384_ONC_PainQuantified.zip)

Successfully created test cases to pass in both Bonnie Production and Bonnie Alpha with this change.