### PR TITLE
BONNIE-972: Relevant Period for CMD

### DIFF
--- a/app/assets/javascripts/datatypes/medication.js.coffee
+++ b/app/assets/javascripts/datatypes/medication.js.coffee
@@ -207,6 +207,12 @@ class CQL_QDM.MedicationDispensed extends CQL_QDM.QDMDatatype
     @_refills = @entry.refills
     @_route = @entry.route
     @_supply = @entry.supply
+    @_relevantPeriodLow = CQL_QDM.Helpers.convertDateTime(@entry.start_time)
+    if @entry.end_time
+      @_relevantPeriodHigh = CQL_QDM.Helpers.convertDateTime(@entry.end_time)
+    else
+      # No end time; high is set to infinity
+      @_relevantPeriodHigh = CQL_QDM.Helpers.infinityDateTime()
 
   ###
   @returns {Date}
@@ -225,6 +231,14 @@ class CQL_QDM.MedicationDispensed extends CQL_QDM.QDMDatatype
   ###
   negationRationale: ->
     new cql.Code(@_negationRationale?.code, @_negationRationale?.code_system)
+
+  ###
+  @returns {Interval<Date>}
+  ###
+  relevantPeriod: ->
+    low = @_relevantPeriodLow
+    high = @_relevantPeriodHigh
+    new cql.Interval(low, high)
 
   ###
   @returns {String}
@@ -266,6 +280,12 @@ class CQL_QDM.MedicationOrder extends CQL_QDM.QDMDatatype
     @_refills = @entry.refills
     @_route = @entry.route
     @_supply = @entry.supply
+    @_relevantPeriodLow = CQL_QDM.Helpers.convertDateTime(@entry.start_time)
+    if @entry.end_time
+      @_relevantPeriodHigh = CQL_QDM.Helpers.convertDateTime(@entry.end_time)
+    else
+      # No end time; high is set to infinity
+      @_relevantPeriodHigh = CQL_QDM.Helpers.infinityDateTime()
 
   ###
   @returns {Date}
@@ -308,6 +328,14 @@ class CQL_QDM.MedicationOrder extends CQL_QDM.QDMDatatype
   ###
   refills: ->
     @_refills
+
+  ###
+  @returns {Interval<Date>}
+  ###
+  relevantPeriod: ->
+    low = @_relevantPeriodLow
+    high = @_relevantPeriodHigh
+    new cql.Interval(low, high)
 
   ###
   @returns {Code}

--- a/spec/javascripts/datatypes/medication_spec.js.coffee
+++ b/spec/javascripts/datatypes/medication_spec.js.coffee
@@ -9,6 +9,11 @@ describe "Medication", ->
       expect(medicationDispensed.relevantPeriod().low).toEqual new cql.DateTime(2012, 3, 17, 10, 17, 0, 0, 0)
       expect(medicationDispensed.relevantPeriod().high).toEqual new cql.DateTime(2012, 3, 17, 10, 32, 0, 0, 0)
 
+    it "has infinite DateTime when no end_time specified", ->
+      medicationDispensed = new CQL_QDM.MedicationDispensed({'start_time':'03/17/2012 10:17 AM'})
+      expect(medicationDispensed.relevantPeriod().low).toEqual new cql.DateTime(2012, 3, 17, 10, 17, 0, 0, 0)
+      expect(medicationDispensed.relevantPeriod().high).toEqual CQL_QDM.Helpers.infinityDateTime()
+
   describe "Order", ->
     it "can be created and simple accessor works", ->
       medicationOrdered = new CQL_QDM.MedicationOrder({'refills':'2'})
@@ -18,3 +23,8 @@ describe "Medication", ->
       medicationOrdered = new CQL_QDM.MedicationOrder({'start_time':'02/21/2012 03:03 AM', 'end_time':'02/22/2012 05:00 PM'})
       expect(medicationOrdered.relevantPeriod().low).toEqual new cql.DateTime(2012, 2, 21, 3, 3, 0, 0, 0)
       expect(medicationOrdered.relevantPeriod().high).toEqual new cql.DateTime(2012, 2, 22, 17, 0, 0, 0, 0)
+
+    it "has infinite DateTime when no end_time specified", ->
+      medicationOrdered = new CQL_QDM.MedicationOrder({'start_time':'02/21/2012 03:03 AM'})
+      expect(medicationOrdered.relevantPeriod().low).toEqual new cql.DateTime(2012, 2, 21, 3, 3, 0, 0, 0)
+      expect(medicationOrdered.relevantPeriod().high).toEqual CQL_QDM.Helpers.infinityDateTime()

--- a/spec/javascripts/datatypes/medication_spec.js.coffee
+++ b/spec/javascripts/datatypes/medication_spec.js.coffee
@@ -3,3 +3,18 @@ describe "Medication", ->
     it "can be created and simple accessor works", ->
       medicationDispensed = new CQL_QDM.MedicationDispensed({'refills':'5'})
       expect(medicationDispensed.refills()).toBe '5'
+
+    it "has revelantPeriod", ->
+      medicationDispensed = new CQL_QDM.MedicationDispensed({'start_time':'03/17/2012 10:17 AM', 'end_time':'03/17/2012 10:32 AM'})
+      expect(medicationDispensed.relevantPeriod().low).toEqual new cql.DateTime(2012, 3, 17, 10, 17, 0, 0, 0)
+      expect(medicationDispensed.relevantPeriod().high).toEqual new cql.DateTime(2012, 3, 17, 10, 32, 0, 0, 0)
+
+  describe "Order", ->
+    it "can be created and simple accessor works", ->
+      medicationOrdered = new CQL_QDM.MedicationOrder({'refills':'2'})
+      expect(medicationOrdered.refills()).toBe '2'
+
+    it "has revelantPeriod", ->
+      medicationOrdered = new CQL_QDM.MedicationOrder({'start_time':'02/21/2012 03:03 AM', 'end_time':'02/22/2012 05:00 PM'})
+      expect(medicationOrdered.relevantPeriod().low).toEqual new cql.DateTime(2012, 2, 21, 3, 3, 0, 0, 0)
+      expect(medicationOrdered.relevantPeriod().high).toEqual new cql.DateTime(2012, 2, 22, 17, 0, 0, 0, 0)


### PR DESCRIPTION
Cumulative Medication Duration support requires Relevant Period for "Medication, Order" and "Medication, Dispensed"

JIRA: https://jira.mitre.org/browse/BONNIE-972
TESTS: added unit tests for new accessors - used TDD, yay!
Using `bundle exec teaspoon --coverage=default` to see coverage.

Was: https://github.com/projecttacoma/cql_qdm_patientapi/pull/69 (scroll to bottom for coverage)
Now:
```
=============================== Coverage summary ===============================
Statements   : 43.91% ( 779/1774 )
Branches     : 7.38% ( 58/786 )
Functions    : 31.81% ( 139/437 )
Lines        : 37.68% ( 587/1558 )
================================================================================
```

This will be integrated with front-end UI changes in Bonnie. PR link forthcoming