### PR TITLE
add 'code' accessor to QDMDatatype

### DIFF
--- a/app/assets/javascripts/datatypes/datatype.js.coffee
+++ b/app/assets/javascripts/datatypes/datatype.js.coffee
@@ -29,7 +29,7 @@ class CQL_QDM.QDMDatatype
     allCodes = []
     for system, codes of @_codes
       for code in codes
-        allCodes.push code: code
+        allCodes.push system: system, code: code
     allCodes
 
   ###
@@ -42,3 +42,14 @@ class CQL_QDM.QDMDatatype
       return new CQL_QDM.Id(@entry._id)
     else
       null
+
+  ###
+  @returns {Code}
+  ###
+  code: ->
+    codeArray = @getCode()
+    if codeArray.length > 0 and codeArray[0].code? and codeArray[0].system?
+      new cql.Code(codeArray[0].code, codeArray[0].system)
+    else
+      null
+

--- a/app/assets/javascripts/datatypes/datatype.js.coffee
+++ b/app/assets/javascripts/datatypes/datatype.js.coffee
@@ -47,9 +47,11 @@ class CQL_QDM.QDMDatatype
   @returns {Code}
   ###
   code: ->
-    codeArray = @getCode()
-    if codeArray.length > 0 and codeArray[0].code? and codeArray[0].system?
-      new cql.Code(codeArray[0].code, codeArray[0].system)
-    else
-      null
+    for system, codes of @_codes
+      for code in codes
+        # return the first code of the first system in @_codes
+        return new cql.Code(code, system)
+        break
+      break
+    null
 

--- a/spec/javascripts/datatypes/qdm_datatype_spec.js.coffee
+++ b/spec/javascripts/datatypes/qdm_datatype_spec.js.coffee
@@ -1,0 +1,15 @@
+describe "QDMDatatype", ->
+  it "should have null code accessor if no codes", ->
+    qdmDatatype = new CQL_QDM.QDMDatatype({})
+    expect(qdmDatatype.code()).toBeNull
+
+  it "should return single code if there is 1 code", ->
+    qdmDatatype = new CQL_QDM.QDMDatatype({codes: {"CPT":["90630"]}})
+    expect(qdmDatatype.code().code).toEqual "90630"
+    expect(qdmDatatype.code().system).toEqual "CPT"
+
+  it "should return first code if there are multiple codes", ->
+    qdmDatatype = new CQL_QDM.QDMDatatype({codes: {"CPT":["90630"], "ABC":["12345"], "DEF":["54321"]}})
+    expect(qdmDatatype.code().code).toEqual "90630"
+    expect(qdmDatatype.code().system).toEqual "CPT"
+


### PR DESCRIPTION
This PR is to add the attribute `code` to the QDM Base Datatype and have it return a single code.

There is an example of this not working on the hmdmmathematica@gmail.com account.  See test case DenExcptPass NoProcSupplyIssueSBEEnc.  Before this change, `.code` will be red.  After the change, it will be green. Unit tests are included, so this was not made a separate JIRA test.

Pull requests into CQL QDM Patient API require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] JIRA ticket for this PR: https://jira.mitre.org/browse/BONNIE-1197
- [x] JIRA ticket links to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced. NA
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Code coverage has not gone down and all code touched or added is covered.
     * In rare situations, this may not be possible or applicable to a PR. In those situations:
         1. Note why this could not be done or is not applicable here:
         2. Add TODOs in the code noting that it requires a test
         3. Add a JIRA task to add the test and link it here:
- [x] Automated regression test(s) pass

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA test links:
- [x] Justification for using JIRA tests:
- [x] JIRA tests have been added to sprint


**Reviewer 1:**

Name: @holmesie 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [x] N/A - JIRA tests have been run and pass
- [x] N/A - You agree with the justification for use of JIRA tests or have provided input on why you disagree


**Reviewer 2:**

Name: @mayerm94
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA tests have been run and pass
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree
