### PR TITLE
Fix jasmine assert functions that were uncalled.

### DIFF
--- a/app/assets/javascripts/types/id.js.coffee
+++ b/app/assets/javascripts/types/id.js.coffee
@@ -9,15 +9,3 @@ Represents the QDM.Id used in the execution engine.
 ###
 class CQL_QDM.Id
   constructor: (@value, @namingSystem) ->
-
-###
-@returns {String}
-###
-namingSystem: ->
-  @namingSystem
-
-###
-@returns {String}
-###
-value: ->
-  @value

--- a/app/assets/javascripts/types/id.js.coffee
+++ b/app/assets/javascripts/types/id.js.coffee
@@ -20,4 +20,4 @@ namingSystem: ->
 @returns {String}
 ###
 value: ->
-  @namingSystem
+  @value

--- a/spec/javascripts/datatypes/adverseevent_spec.js.coffee
+++ b/spec/javascripts/datatypes/adverseevent_spec.js.coffee
@@ -1,7 +1,7 @@
 describe "Adverse Event", ->
   it "should show null relevantPeriod", ->
     adverseEvent = new CQL_QDM.AdverseEvent({})
-    expect(adverseEvent.relevantPeriod()).toBeNull
+    expect(adverseEvent.relevantPeriod()).toBeNull()
 
   it "should show valid relevantPeriod", ->
     adverseEvent = new CQL_QDM.AdverseEvent({'start_time': '08/31/2017 1:00 AM', 'end_time': '08/31/2017 2:00 AM'})
@@ -9,7 +9,7 @@ describe "Adverse Event", ->
 
   it "should return null for a null type", ->
     adverseEvent = new CQL_QDM.AdverseEvent({})
-    expect(adverseEvent.type()).toBeNull
+    expect(adverseEvent.type()).toBeNull()
 
   it "should show valid type", ->
     adverseEvent = new CQL_QDM.AdverseEvent({'type': {'code': '12345', 'code_system': 'Bar'}})
@@ -17,7 +17,7 @@ describe "Adverse Event", ->
 
   it "should return null for a null facility location", ->
     adverseEvent = new CQL_QDM.AdverseEvent({})
-    expect(adverseEvent.facilityLocation()).toBeNull
+    expect(adverseEvent.facilityLocation()).toBeNull()
 
   it "should show valid facility location", ->
     adverseEvent = new CQL_QDM.AdverseEvent({'facility': {'values': [{'code': {'code': '123456', 'code_system': 'Foo'}, 'display': 'A Facility'}]}})

--- a/spec/javascripts/datatypes/caregoal_spec.js.coffee
+++ b/spec/javascripts/datatypes/caregoal_spec.js.coffee
@@ -8,7 +8,7 @@ describe "CareGoal", ->
 
   it "should show null relevantPeriod", ->
     careGoal = new CQL_QDM.CareGoal({})
-    expect(careGoal.relevantPeriod()).toBeNull
+    expect(careGoal.relevantPeriod()).toBeNull()
 
   it "should show valid relevantPeriod", ->
     careGoal = new CQL_QDM.CareGoal({'start_time': '08/31/2017 1:00 AM', 'end_time': '08/31/2017 2:00 AM'})
@@ -16,4 +16,4 @@ describe "CareGoal", ->
 
   it "should show not respond to authorDatetime", ->
     careGoal = new CQL_QDM.CareGoal({})
-    expect(careGoal.authorDatetime).not.toBeDefined
+    expect(careGoal.authorDatetime).not.toBeDefined()

--- a/spec/javascripts/datatypes/datatype_spec.js.coffee
+++ b/spec/javascripts/datatypes/datatype_spec.js.coffee
@@ -37,4 +37,4 @@ describe "QDMDatatype", ->
 
   it "should return null for a datatype not based on an entry", ->
     birthdate = new CQL_QDM.PatientCharacteristicBirthdate({_id: "1234567890", birthdate: "1246400000"})
-    expect(birthdate.id()).toBeNull
+    expect(birthdate.id()).toBeNull()

--- a/spec/javascripts/datatypes/device_spec.js.coffee
+++ b/spec/javascripts/datatypes/device_spec.js.coffee
@@ -2,7 +2,7 @@ describe "Device", ->
   describe "Applied", ->
     it "should show null relevantPeriod", ->
       deviceApplied = new CQL_QDM.DeviceApplied({})
-      expect(deviceApplied.relevantPeriod()).toBeNull
+      expect(deviceApplied.relevantPeriod()).toBeNull()
 
     it "should show valid relevantPeriod", ->
       deviceApplied = new CQL_QDM.DeviceApplied({'start_time': '08/31/2017 1:00 AM', 'end_time': '08/31/2017 2:00 AM'})

--- a/spec/javascripts/datatypes/diagnosticstudy_spec.js.coffee
+++ b/spec/javascripts/datatypes/diagnosticstudy_spec.js.coffee
@@ -2,7 +2,7 @@ describe "Diagnostic Study", ->
   describe "Performed", ->
     it "should show null relevantPeriod", ->
       diagnosticStudyPerformed = new CQL_QDM.DiagnosticStudyPerformed({})
-      expect(diagnosticStudyPerformed.relevantPeriod()).toBeNull
+      expect(diagnosticStudyPerformed.relevantPeriod()).toBeNull()
 
     it "should show valid relevantPeriod", ->
       diagnosticStudyPerformed = new CQL_QDM.DiagnosticStudyPerformed({'start_time': '08/31/2017 1:00 AM', 'end_time': '08/31/2017 2:00 AM'})
@@ -10,7 +10,7 @@ describe "Diagnostic Study", ->
 
     it "should return null for a null facility location", ->
       diagnosticStudyPerformed = new CQL_QDM.DiagnosticStudyPerformed({})
-      expect(diagnosticStudyPerformed.facilityLocation()).toBeNull
+      expect(diagnosticStudyPerformed.facilityLocation()).toBeNull()
 
     it "should show valid facility location", ->
       diagnosticStudyPerformed = new CQL_QDM.DiagnosticStudyPerformed({'facility': {'values': [{'code': {'code': '123456', 'code_system': 'Foo'}, 'display': 'A Facility'}]}})

--- a/spec/javascripts/datatypes/encounter_spec.js.coffee
+++ b/spec/javascripts/datatypes/encounter_spec.js.coffee
@@ -26,7 +26,7 @@ describe "Encounter", ->
 
     it "should show null relevantPeriod", ->
       encounterPerformed = new CQL_QDM.EncounterPerformed({})
-      expect(encounterPerformed.relevantPeriod()).toBeNull
+      expect(encounterPerformed.relevantPeriod()).toBeNull()
 
     it "should show valid relevantPeriod", ->
       encounterPerformed = new CQL_QDM.EncounterPerformed({'start_time': '08/31/2017 1:00 AM', 'end_time': '08/31/2017 2:00 AM'})
@@ -35,7 +35,7 @@ describe "Encounter", ->
   describe "Order", ->
     it "should return null for a null facility location", ->
       encounterOrder = new CQL_QDM.EncounterOrder({})
-      expect(encounterOrder.facilityLocation()).toBeNull
+      expect(encounterOrder.facilityLocation()).toBeNull()
 
     it "should show valid facility location", ->
       encounterOrder = new CQL_QDM.EncounterOrder({'facility': {'values': [{'code': {'code': '123456', 'code_system': 'Foo'}, 'display': 'A Facility'}]}})

--- a/spec/javascripts/datatypes/familyhistory_spec.js.coffee
+++ b/spec/javascripts/datatypes/familyhistory_spec.js.coffee
@@ -1,7 +1,7 @@
 describe "FamilyHistory", ->
   it "should return null for a null relationship", ->
     familyHistory = new CQL_QDM.FamilyHistory({})
-    expect(familyHistory.relationship()).toBeNull
+    expect(familyHistory.relationship()).toBeNull()
 
   it "should show valid relationship", ->
     familyHistory = new CQL_QDM.FamilyHistory({'relationshipToPatient': {'code': '12345', 'code_system': 'Bar'}})

--- a/spec/javascripts/datatypes/id_spec.js.coffee
+++ b/spec/javascripts/datatypes/id_spec.js.coffee
@@ -1,11 +1,11 @@
 describe 'ID', ->
   it 'Should handle a blank namingSystem', ->
     id = new CQL_QDM.Id(null, null)
-    expect(id.namingSystem).not.toBeDefined
+    expect(id.namingSystem).toBeNull()
 
   it 'Should handle a blank value', ->
     id = new CQL_QDM.Id()
-    expect(id.value).not.toBeDefined
+    expect(id.value).not.toBeDefined()
 
   it 'Should handle a present namingSystem and value', ->
     id = new CQL_QDM.Id(5, 'foo')

--- a/spec/javascripts/datatypes/intervention_spec.js.coffee
+++ b/spec/javascripts/datatypes/intervention_spec.js.coffee
@@ -2,7 +2,7 @@ describe "Intervention", ->
   describe "Performed", ->
     it "should show null relevantPeriod", ->
       interventionPerformed = new CQL_QDM.InterventionPerformed({})
-      expect(interventionPerformed.relevantPeriod()).toBeNull
+      expect(interventionPerformed.relevantPeriod()).toBeNull()
 
     it "should show valid relevantPeriod", ->
       interventionPerformed = new CQL_QDM.InterventionPerformed({'start_time': '08/31/2017 1:00 AM', 'end_time': '08/31/2017 2:00 AM'})

--- a/spec/javascripts/datatypes/laboratory_test_spec.js.coffee
+++ b/spec/javascripts/datatypes/laboratory_test_spec.js.coffee
@@ -30,7 +30,7 @@ describe "Laboratory Test", ->
 
     it "should show null relevantPeriod", ->
       laboratoryTestPerformed = new CQL_QDM.AdverseEvent({})
-      expect(laboratoryTestPerformed.relevantPeriod()).toBeNull
+      expect(laboratoryTestPerformed.relevantPeriod()).toBeNull()
 
     it "should show valid relevantPeriod", ->
       laboratoryTestPerformed = new CQL_QDM.AdverseEvent({'start_time': '08/31/2017 1:00 AM', 'end_time': '08/31/2017 2:00 AM'})

--- a/spec/javascripts/datatypes/medication_spec.js.coffee
+++ b/spec/javascripts/datatypes/medication_spec.js.coffee
@@ -16,7 +16,7 @@ describe "Medication", ->
 
     it "should show null relevantPeriod", ->
       medicationDispensed = new CQL_QDM.MedicationDispensed({})
-      expect(medicationDispensed.relevantPeriod()).toBeNull
+      expect(medicationDispensed.relevantPeriod()).toBeNull()
 
     it "should show valid relevantPeriod", ->
       medicationDispensed = new CQL_QDM.MedicationDispensed({'start_time': '08/31/2017 1:00 AM', 'end_time': '08/31/2017 2:00 AM'})
@@ -45,7 +45,7 @@ describe "Medication", ->
 
     it "should show null relevantPeriod", ->
       medicationOrdered = new CQL_QDM.MedicationOrder({})
-      expect(medicationOrdered.relevantPeriod()).toBeNull
+      expect(medicationOrdered.relevantPeriod()).toBeNull()
 
     it "should show valid relevantPeriod", ->
       medicationOrdered = new CQL_QDM.MedicationOrder({'start_time': '08/31/2017 1:00 AM', 'end_time': '08/31/2017 2:00 AM'})
@@ -59,7 +59,7 @@ describe "Medication", ->
   describe "Active", ->
     it "should show null relevantPeriod", ->
       medicationActive = new CQL_QDM.MedicationActive({})
-      expect(medicationActive.relevantPeriod()).toBeNull
+      expect(medicationActive.relevantPeriod()).toBeNull()
 
     it "should show valid relevantPeriod", ->
       medicationActive = new CQL_QDM.MedicationActive({'start_time': '08/31/2017 1:00 AM', 'end_time': '08/31/2017 2:00 AM'})
@@ -68,7 +68,7 @@ describe "Medication", ->
   describe "Administered", ->
     it "should show null relevantPeriod", ->
       medicationAdministered = new CQL_QDM.MedicationAdministered({})
-      expect(medicationAdministered.relevantPeriod()).toBeNull
+      expect(medicationAdministered.relevantPeriod()).toBeNull()
 
     it "should show valid relevantPeriod", ->
       medicationAdministered = new CQL_QDM.MedicationAdministered({'start_time': '08/31/2017 1:00 AM', 'end_time': '08/31/2017 2:00 AM'})
@@ -77,7 +77,7 @@ describe "Medication", ->
     it "should not support refills()", ->
       # MedicationAdministered does not support refills, according to the model info file
       medicationAdministered = new CQL_QDM.MedicationAdministered({'refills': 2})
-      expect(medicationAdministered.refills).not.toBeDefined
+      expect(medicationAdministered.refills).not.toBeDefined()
 
     it "should throw an error if frequency() is called", ->
       medicationAdministered = new CQL_QDM.MedicationAdministered({'start_time': '08/31/2017 1:00 AM', 'end_time': '08/31/2017 2:00 AM'})

--- a/spec/javascripts/datatypes/patient_characteristic_expired_spec.js.coffee
+++ b/spec/javascripts/datatypes/patient_characteristic_expired_spec.js.coffee
@@ -1,7 +1,7 @@
 describe "Patient Characteristic Expired", ->
   xit "should show null deathdate", ->
     patientCharacteristicExpired = new CQL_QDM.PatientCharacteristicExpired({})
-    expect(patientCharacteristicExpired.expiredDatetime()).toBeNull
+    expect(patientCharacteristicExpired.expiredDatetime()).toBeNull()
 
   xit "should show valid deathdate", ->
     patientCharacteristicExpired = new CQL_QDM.PatientCharacteristicExpired({'deathdate': '08/31/2017 1:00 AM'})

--- a/spec/javascripts/datatypes/patient_characteristic_payer_spec.js.coffee
+++ b/spec/javascripts/datatypes/patient_characteristic_payer_spec.js.coffee
@@ -1,7 +1,7 @@
 describe "Patient Characteristic Payer", ->
   it "should show null relevantPeriod", ->
     patientCharacteristicPayer = new CQL_QDM.PatientCharacteristicPayer({})
-    expect(patientCharacteristicPayer.relevantPeriod()).toBeNull
+    expect(patientCharacteristicPayer.relevantPeriod()).toBeNull()
 
   it "should show valid relevantPeriod", ->
     patientCharacteristicPayer = new CQL_QDM.PatientCharacteristicPayer({'start_time': '08/31/2017 1:00 AM', 'end_time': '08/31/2017 2:00 AM'})

--- a/spec/javascripts/datatypes/physicalexam_spec.js.coffee
+++ b/spec/javascripts/datatypes/physicalexam_spec.js.coffee
@@ -2,7 +2,7 @@ describe "Physical Exam", ->
   describe "Performed", ->
     it "should show null relevantPeriod", ->
       physicalExamPerformed = new CQL_QDM.PhysicalExamPerformed({})
-      expect(physicalExamPerformed.relevantPeriod()).toBeNull
+      expect(physicalExamPerformed.relevantPeriod()).toBeNull()
 
     it "should show valid relevantPeriod", ->
       physicalExamPerformed = new CQL_QDM.PhysicalExamPerformed({'start_time': '08/31/2017 1:00 AM', 'end_time': '08/31/2017 2:00 AM'})

--- a/spec/javascripts/datatypes/procedure_spec.js.coffee
+++ b/spec/javascripts/datatypes/procedure_spec.js.coffee
@@ -2,7 +2,7 @@ describe "Procedure", ->
   describe "Performed", ->
     it "should show null relevantPeriod", ->
       procedurePerformed = new CQL_QDM.ProcedurePerformed({})
-      expect(procedurePerformed.relevantPeriod()).toBeNull
+      expect(procedurePerformed.relevantPeriod()).toBeNull()
 
     it "should show valid relevantPeriod", ->
       procedurePerformed = new CQL_QDM.ProcedurePerformed({'start_time': '08/31/2017 1:00 AM', 'end_time': '08/31/2017 2:00 AM'})

--- a/spec/javascripts/datatypes/qdm_datatype_spec.js.coffee
+++ b/spec/javascripts/datatypes/qdm_datatype_spec.js.coffee
@@ -1,7 +1,7 @@
 describe "QDMDatatype", ->
   it "should have null code accessor if no codes", ->
     qdmDatatype = new CQL_QDM.QDMDatatype({})
-    expect(qdmDatatype.code()).toBeNull
+    expect(qdmDatatype.code()).toBeNull()
 
   it "should return single code if there is 1 code", ->
     qdmDatatype = new CQL_QDM.QDMDatatype({codes: {"CPT":["90630"]}})

--- a/spec/javascripts/datatypes/substance_spec.js.coffee
+++ b/spec/javascripts/datatypes/substance_spec.js.coffee
@@ -2,7 +2,7 @@ describe "Substance", ->
   describe "Administered", ->
     it "should show null relevantPeriod", ->
       substanceAdministered = new CQL_QDM.SubstanceAdministered({})
-      expect(substanceAdministered.relevantPeriod()).toBeNull
+      expect(substanceAdministered.relevantPeriod()).toBeNull()
 
     it "should show valid relevantPeriod", ->
       substanceAdministered = new CQL_QDM.SubstanceAdministered({'start_time': '08/31/2017 1:00 AM', 'end_time': '08/31/2017 2:00 AM'})
@@ -10,7 +10,7 @@ describe "Substance", ->
 
     it "should throw an error if refills() is called", ->
       substanceAdministered = new CQL_QDM.SubstanceAdministered({'start_time': '08/31/2017 1:00 AM', 'end_time': '08/31/2017 2:00 AM'})
-      expect(substanceAdministered.refills).not.toBeDefined
+      expect(substanceAdministered.refills).not.toBeDefined()
       expect(substanceAdministered.frequency).toThrowError('Bonnie does not currently support SubstanceAdministered.frequency')
 
   describe "Order", ->

--- a/spec/javascripts/datatypes/symptom_spec.js.coffee
+++ b/spec/javascripts/datatypes/symptom_spec.js.coffee
@@ -2,7 +2,7 @@ describe "Symptom", ->
   describe "Prevalence", ->
     it "should show null prevalencePeriod", ->
       symptom = new CQL_QDM.Symptom({})
-      expect(symptom.prevalencePeriod()).toEqual null
+      expect(symptom.prevalencePeriod()).toBeNull()
 
     it "should show valid prevalencePeriod", ->
       symptom = new CQL_QDM.Symptom({'start_time': '08/31/2017 1:00 AM', 'end_time': '08/31/2017 2:00 AM'})


### PR DESCRIPTION
Jasmine syntax requires the parenthese in the assert statements:
`expect(true).toBeFalse` will pass because it returns undefined.
`expect(true).toBeFalse()` is the correct syntax.

All tests still passed after updating with the exception if id_spec.js.coffee,
which just needed to check for null rather then undefined.

Pull requests into CQL QDM Patient API require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] JIRA ticket for this PR: https://jira.mitre.org/browse/BONNIE-1212
- [x] JIRA ticket links to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] N/A If UI changes have been made, google WAVE plug-in has been executed to ensure no 508 issues were introduced.
- [x] Tests are included and test edge cases N/A
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Code coverage has not gone down and all code touched or added is covered.
     * In rare situations, this may not be possible or applicable to a PR. In those situations:
         1. Note why this could not be done or is not applicable here:
         2. Add TODOs in the code noting that it requires a test
         3. Add a JIRA task to add the test and link it here:
- [x] Automated regression test(s) pass N/A only changes in tests

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA test links: N/A
- [x] Justification for using JIRA tests: N/A
- [x] JIRA tests have been added to sprint N/A


**Reviewer 1:**

Name: @c-monkey
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA tests have been run and pass - N/A
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree - N/A


**Reviewer 2:**

Name: @jbradl11 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA tests have been run and pass - N/A
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree - N/A
