### PR TITLE
Bonnie 1503

### DIFF
--- a/app/assets/javascripts/datatypes/caregoal.js.coffee
+++ b/app/assets/javascripts/datatypes/caregoal.js.coffee
@@ -52,8 +52,8 @@ class CQL_QDM.CareGoal extends CQL_QDM.QDMDatatype
   ###
   targetOutcome: ->
     if @_targetOutcome?
-      if @_targetOutcome?['unit']?
-        new cql.Quantity({unit: @_targetOutcome['unit'], value: @_targetOutcome['scalar']})
+      if @_targetOutcome?['units']?
+        new cql.Quantity({unit: @_targetOutcome['units'], value: @_targetOutcome['scalar']})
       else
         new cql.Code(@_targetOutcome.code, @_targetOutcome.code_system)
     else

--- a/app/assets/javascripts/datatypes/immunization.js.coffee
+++ b/app/assets/javascripts/datatypes/immunization.js.coffee
@@ -34,7 +34,7 @@ class CQL_QDM.ImmunizationAdministered extends CQL_QDM.QDMDatatype
   ###
   dosage: ->
     if @_dosage?
-      new cql.Quantity({unit: @_dosage['unit'], value: @_dosage['scalar']})
+      new cql.Quantity({unit: @_dosage['units'], value: @_dosage['scalar']})
     else
       null
 
@@ -70,7 +70,7 @@ class CQL_QDM.ImmunizationAdministered extends CQL_QDM.QDMDatatype
   ###
   supply: ->
     if @_supply?
-      new cql.Quantity({unit: @_supply['unit'], value: @_supply['scalar']})
+      new cql.Quantity({unit: @_supply['units'], value: @_supply['scalar']})
     else
       null
 
@@ -111,7 +111,7 @@ class CQL_QDM.ImmunizationOrder extends CQL_QDM.QDMDatatype
   ###
   dosage: ->
     if @_dosage?
-      new cql.Quantity({unit: @_dosage['unit'], value: @_dosage['scalar']})
+      new cql.Quantity({unit: @_dosage['units'], value: @_dosage['scalar']})
     else
       null
 
@@ -147,6 +147,6 @@ class CQL_QDM.ImmunizationOrder extends CQL_QDM.QDMDatatype
   ###
   supply: ->
     if @_supply?
-      new cql.Quantity({unit: @_supply['unit'], value: @_supply['scalar']})
+      new cql.Quantity({unit: @_supply['units'], value: @_supply['scalar']})
     else
       null

--- a/app/assets/javascripts/datatypes/laboratorytest.js.coffee
+++ b/app/assets/javascripts/datatypes/laboratorytest.js.coffee
@@ -124,19 +124,19 @@ class CQL_QDM.LaboratoryTestPerformed extends CQL_QDM.QDMDatatype
     # According to documentation, this is assumed to be a 'Quantity'
     high = null
     low = null
-    if @_referenceRangeHigh?['unit']?
+    if @_referenceRangeHigh?['units']?
       high_obj =
         unit:
-          @_referenceRangeHigh['unit']
+          @_referenceRangeHigh['units']
         value:
-          @_referenceRangeHigh['value']
+          @_referenceRangeHigh['scalar']
       high = new cql.Quantity(high_obj)
-    if @_referenceRangeLow?['unit']?
+    if @_referenceRangeLow?['units']?
       low_obj =
         unit:
-          @_referenceRangeLow['unit']
+          @_referenceRangeLow['units']
         value:
-          @_referenceRangeLow['value']
+          @_referenceRangeLow['scalar']
       low = new cql.Quantity(low_obj)
     if low?
       new cql.Interval(low, high)

--- a/app/assets/javascripts/datatypes/medication.js.coffee
+++ b/app/assets/javascripts/datatypes/medication.js.coffee
@@ -43,7 +43,7 @@ class CQL_QDM.MedicationActive extends CQL_QDM.QDMDatatype
   ###
   frequency: ->
     if @_frequency?
-      new cql.Code(@_frequency.code, @_frequency.code_system, @_frequency.version, @_frequency.title)
+      new cql.Code(@_frequency.code, @_frequency.code_system)
     else
       null
 
@@ -123,7 +123,7 @@ class CQL_QDM.MedicationAdministered extends CQL_QDM.QDMDatatype
   ###
   frequency: ->
     if @_frequency?
-      new cql.Code(@_frequency.code, @_frequency.code_system, @_frequency.version, @_frequency.title)
+      new cql.Code(@_frequency.code, @_frequency.code_system)
     else
       null
 
@@ -215,7 +215,7 @@ class CQL_QDM.MedicationDischarge extends CQL_QDM.QDMDatatype
   ###
   frequency: ->
     if @_frequency?
-      new cql.Code(@_frequency.code, @_frequency.code_system, @_frequency.version, @_frequency.title)
+      new cql.Code(@_frequency.code, @_frequency.code_system)
     else
       null
 
@@ -306,7 +306,7 @@ class CQL_QDM.MedicationDispensed extends CQL_QDM.QDMDatatype
   ###
   frequency: ->
     if @_frequency?
-      new cql.Code(@_frequency.code, @_frequency.code_system, @_frequency.version, @_frequency.title)
+      new cql.Code(@_frequency.code, @_frequency.code_system)
     else
       null
 
@@ -412,7 +412,7 @@ class CQL_QDM.MedicationOrder extends CQL_QDM.QDMDatatype
   ###
   frequency: ->
     if @_frequency?
-      new cql.Code(@_frequency.code, @_frequency.code_system, @_frequency.version, @_frequency.title)
+      new cql.Code(@_frequency.code, @_frequency.code_system)
     else
       null
 

--- a/app/assets/javascripts/datatypes/medication.js.coffee
+++ b/app/assets/javascripts/datatypes/medication.js.coffee
@@ -34,7 +34,7 @@ class CQL_QDM.MedicationActive extends CQL_QDM.QDMDatatype
   ###
   dosage: ->
     if @_dosage?
-      new cql.Quantity({unit: @_dosage['unit'], value: @_dosage['scalar']})
+      new cql.Quantity({unit: @_dosage['units'], value: @_dosage['scalar']})
     else
       null
 
@@ -72,7 +72,7 @@ class CQL_QDM.MedicationActive extends CQL_QDM.QDMDatatype
   ###
   supply: ->
     if @_supply?
-      new cql.Quantity({unit: @_supply['unit'], value: @_supply['scalar']})
+      new cql.Quantity({unit: @_supply['units'], value: @_supply['scalar']})
     else
       null
 
@@ -114,7 +114,7 @@ class CQL_QDM.MedicationAdministered extends CQL_QDM.QDMDatatype
   ###
   dosage: ->
     if @_dosage?
-      new cql.Quantity({unit: @_dosage['unit'], value: @_dosage['scalar']})
+      new cql.Quantity({unit: @_dosage['units'], value: @_dosage['scalar']})
     else
       null
 
@@ -170,7 +170,7 @@ class CQL_QDM.MedicationAdministered extends CQL_QDM.QDMDatatype
   ###
   supply: ->
     if @_supply?
-      new cql.Quantity({unit: @_supply['unit'], value: @_supply['scalar']})
+      new cql.Quantity({unit: @_supply['units'], value: @_supply['scalar']})
     else
       null
 
@@ -206,7 +206,7 @@ class CQL_QDM.MedicationDischarge extends CQL_QDM.QDMDatatype
   ###
   dosage: ->
     if @_dosage?
-      new cql.Quantity({unit: @_dosage['unit'], value: @_dosage['scalar']})
+      new cql.Quantity({unit: @_dosage['units'], value: @_dosage['scalar']})
     else
       null
 
@@ -251,7 +251,7 @@ class CQL_QDM.MedicationDischarge extends CQL_QDM.QDMDatatype
   ###
   supply: ->
     if @_supply?
-      new cql.Quantity({unit: @_supply['unit'], value: @_supply['scalar']})
+      new cql.Quantity({unit: @_supply['units'], value: @_supply['scalar']})
     else
       null
 
@@ -297,7 +297,7 @@ class CQL_QDM.MedicationDispensed extends CQL_QDM.QDMDatatype
   ###
   dosage: ->
     if @_dosage?
-      new cql.Quantity({unit: @_dosage['unit'], value: @_dosage['scalar']})
+      new cql.Quantity({unit: @_dosage['units'], value: @_dosage['scalar']})
     else
       null
 
@@ -353,7 +353,7 @@ class CQL_QDM.MedicationDispensed extends CQL_QDM.QDMDatatype
   ###
   supply: ->
     if @_supply?
-      new cql.Quantity({unit: @_supply['unit'], value: @_supply['scalar']})
+      new cql.Quantity({unit: @_supply['units'], value: @_supply['scalar']})
     else
       null
 
@@ -403,7 +403,7 @@ class CQL_QDM.MedicationOrder extends CQL_QDM.QDMDatatype
   ###
   dosage: ->
     if @_dosage?
-      new cql.Quantity({unit: @_dosage['unit'], value: @_dosage['scalar']})
+      new cql.Quantity({unit: @_dosage['units'], value: @_dosage['scalar']})
     else
       null
 
@@ -477,6 +477,6 @@ class CQL_QDM.MedicationOrder extends CQL_QDM.QDMDatatype
   ###
   supply: ->
     if @_supply?
-      new cql.Quantity({unit: @_supply['unit'], value: @_supply['scalar']})
+      new cql.Quantity({unit: @_supply['units'], value: @_supply['scalar']})
     else
       null

--- a/app/assets/javascripts/datatypes/substance.js.coffee
+++ b/app/assets/javascripts/datatypes/substance.js.coffee
@@ -41,7 +41,7 @@ class CQL_QDM.SubstanceAdministered extends CQL_QDM.QDMDatatype
   ###
   dosage: ->
     if @_dosage?
-      new cql.Quantity({unit: @_dosage['unit'], value: @_dosage['scalar']})
+      new cql.Quantity({unit: @_dosage['units'], value: @_dosage['scalar']})
     else
       null
 
@@ -88,7 +88,7 @@ class CQL_QDM.SubstanceAdministered extends CQL_QDM.QDMDatatype
   ###
   supply: ->
     if @_supply?
-      new cql.Quantity({unit: @_supply['unit'], value: @_supply['scalar']})
+      new cql.Quantity({unit: @_supply['units'], value: @_supply['scalar']})
     else
       null
 
@@ -124,7 +124,7 @@ class CQL_QDM.SubstanceOrder extends CQL_QDM.QDMDatatype
   ###
   dosage: ->
     if @_dosage?
-      new cql.Quantity({unit: @_dosage['unit'], value: @_dosage['scalar']})
+      new cql.Quantity({unit: @_dosage['units'], value: @_dosage['scalar']})
     else
       null
 
@@ -187,7 +187,7 @@ class CQL_QDM.SubstanceOrder extends CQL_QDM.QDMDatatype
   ###
   supply: ->
     if @_supply?
-      new cql.Quantity({unit: @_supply['unit'], value: @_supply['scalar']})
+      new cql.Quantity({unit: @_supply['units'], value: @_supply['scalar']})
     else
       null
 
@@ -224,7 +224,7 @@ class CQL_QDM.SubstanceRecommended extends CQL_QDM.QDMDatatype
   ###
   dosage: ->
     if @_dosage?
-      new cql.Quantity({unit: @_dosage['unit'], value: @_dosage['scalar']})
+      new cql.Quantity({unit: @_dosage['units'], value: @_dosage['scalar']})
     else
       null
 
@@ -287,6 +287,6 @@ class CQL_QDM.SubstanceRecommended extends CQL_QDM.QDMDatatype
   ###
   supply: ->
     if @_supply?
-      new cql.Quantity({unit: @_supply['unit'], value: @_supply['scalar']})
+      new cql.Quantity({unit: @_supply['units'], value: @_supply['scalar']})
     else
       null

--- a/spec/javascripts/datatypes/caregoal_spec.js.coffee
+++ b/spec/javascripts/datatypes/caregoal_spec.js.coffee
@@ -1,4 +1,48 @@
 describe "CareGoal", ->
+  careGoalEntry = {
+    "_id":"5afef50608fa185ad5e0a8c1",
+    "codes":{"LOINC":["29463-7"]},
+    "description":"Care Goal: Body Weight",
+    "end_time":1337328900,
+    "health_record_field":null,
+    "mood_code":"EVN",
+    "negationInd":null,
+    "negationReason":null,
+    "oid":"2.16.840.1.113883.3.560.1.9",
+    "reason":null,
+    "references":[{"_id":"5afef50608fa185ad5e0a8c2","referenced_id":"5afef50608fa185ad5e0a8c3","referenced_type":"Medication","type":"Related To"}],
+    "specifics":null,
+    "start_time":1337328000,
+    "status_code":{"HL7 ActStatus":[null]},
+    "targetOutcome":{"scalar":"25","units":"mg"},
+    "time":null}
+
+  it "should return a relevantPeriod interval", ->
+    careGoal = new CQL_QDM.CareGoal(careGoalEntry)
+    expect(careGoal.relevantPeriod()).toEqual new cql.Interval(new cql.DateTime(2012, 5, 18, 8, 0, 0, 0, 0), new cql.DateTime(2012, 5, 18, 8, 15, 0, 0, 0))
+
+  it "should return null if no relevant period is specified", ->
+    careGoal = new CQL_QDM.CareGoal({})
+    expect(careGoal.relevantPeriod()).toEqual null
+
+  it "should return relatedTo array", ->
+    careGoal = new CQL_QDM.CareGoal(careGoalEntry)
+    expect(careGoal.relatedTo().length).toBe 1
+    referenceId = new CQL_QDM.Id('5afef50608fa185ad5e0a8c3')
+    expect(careGoal.relatedTo()[0]).toEqual referenceId
+
+  it "should return an empty array if relatedTo is unused", ->
+    careGoal = new CQL_QDM.CareGoal({})
+    expect(careGoal.relatedTo()).toEqual []
+
+  it "should return a targetOutcome quantity", ->
+    careGoal = new CQL_QDM.CareGoal(careGoalEntry)
+    expect(careGoal.targetOutcome()).toEqual new cql.Quantity(unit: 'mg', value: '25')
+
+  it "should return null if no targetOutcome is specified", ->
+    careGoal = new CQL_QDM.CareGoal({})
+    expect(careGoal.targetOutcome()).toEqual null
+
   it "should return a list of ids when relatedTo is called", ->
     careGoal = new CQL_QDM.CareGoal({'references': [{'referenced_id':'1234567890', 'type':'Example'},{'referenced_id':'0987654321', 'type':'Example'}]})
     expect(careGoal.relatedTo().length).toBe 2

--- a/spec/javascripts/datatypes/immunization_spec.js.coffee
+++ b/spec/javascripts/datatypes/immunization_spec.js.coffee
@@ -1,0 +1,186 @@
+describe "Immunization", ->
+  describe "Administered", ->
+    immunizationAdministeredEntry = {
+        "_id":"5afc581e08fa180a0efc7fc8",
+        "active_datetime":null,
+        "administrationTiming":null,
+        "allowedAdministrations":null,
+        "anatomical_approach":null,
+        "codes":{"CVX":["106"]},
+        "cumulativeMedicationDuration":null,
+        "deliveryMethod":null,
+        "description":"Immunization, Administered: DTaP Vaccine",
+        "dose":{"scalar":"23","units":"mg"},
+        "doseIndicator":null,
+        "doseRestriction":null,
+        "end_time":null,
+        "freeTextSig":null,
+        "fulfillmentInstructions":null,
+        "health_record_field":null,
+        "indication":null,
+        "method":null,
+        "mood_code":"EVN",
+        "negationInd":true,
+        "negationReason":{"code_system":"SNOMED-CT","code":"10082001"},
+        "oid":"2.16.840.1.113883.10.20.28.3.112",
+        "patientInstructions":null,
+        "productForm":null,
+        "reaction":null,
+        "reason":{"code_system":"CVX","code":"120","title":"Haemophilus Influenzae Type B (HiB) Vaccine"},
+        "refills":null,
+        "route":{"code_system":"CVX","code":"100","title":"Pneumococcal Conjugate Vaccine"},
+        "signed_datetime":null,
+        "specifics":null,
+        "start_time":1337155200,
+        "statusOfMedication":null,
+        "status_code":{"HL7 ActStatus":["administered"]},
+        "supply":{"scalar":"14","units":"mg"},
+        "time":null,
+        "typeOfMedication":null,
+        "vehicle":null
+    } 
+
+    it "should return an author DateTime", ->
+      immunizationAdministered = new CQL_QDM.ImmunizationAdministered(immunizationAdministeredEntry)
+      expect(immunizationAdministered.authorDatetime()).toEqual new cql.DateTime(2012, 5, 16, 8, 0, 0, 0, 0)
+
+    it "should return null authorDateTime when no is start_time is specified", ->
+       immunizationAdministered = new CQL_QDM.ImmunizationAdministered({})
+       expect(immunizationAdministered.authorDatetime()).toEqual null
+
+    it "should return a dosage quantity", ->
+      immunizationAdministered = new CQL_QDM.ImmunizationAdministered(immunizationAdministeredEntry)
+      expect(immunizationAdministered.dosage()).toEqual new cql.Quantity({unit: 'mg', value: '23'})
+
+    it "should return null if no dosage is specified", ->
+      immunizationAdministered = new CQL_QDM.ImmunizationAdministered({})
+      expect(immunizationAdministered.dosage()).toEqual null
+
+    it "should return a negation rationale code", ->
+      immunizationAdministered = new CQL_QDM.ImmunizationAdministered(immunizationAdministeredEntry)
+      expect(immunizationAdministered.negationRationale()).toEqual new cql.Code('10082001', 'SNOMED-CT')
+
+    it "should return null if no negation rationale is specified", ->
+      immunizationAdministered = new CQL_QDM.ImmunizationAdministered({})
+      expect(immunizationAdministered.negationRationale()).toEqual null
+
+    it "should return a reason code", ->
+      immunizationAdministered = new CQL_QDM.ImmunizationAdministered(immunizationAdministeredEntry)
+      expect(immunizationAdministered.reason()).toEqual new cql.Code('120', 'CVX')
+
+    it "should return null if no reason is specified", ->
+      immunizationAdministered = new CQL_QDM.ImmunizationAdministered({})
+      expect(immunizationAdministered.reason()).toEqual null
+
+    it "should return a route code", ->
+      immunizationAdministered = new CQL_QDM.ImmunizationAdministered(immunizationAdministeredEntry)
+      expect(immunizationAdministered.route()).toEqual new cql.Code('100', 'CVX')
+
+    it "should return null if no route is specified", ->
+      immunizationAdministered = new CQL_QDM.ImmunizationAdministered({})
+      expect(immunizationAdministered.route()).toEqual null
+
+    it "should return a supply quantity", ->
+      immunizationAdministered = new CQL_QDM.ImmunizationAdministered(immunizationAdministeredEntry)
+      expect(immunizationAdministered.supply()).toEqual new cql.Quantity({unit: 'mg', value: '14'})
+
+    it "should return null if no supply is specified", ->
+      immunizationAdministered = new CQL_QDM.ImmunizationAdministered({})
+      expect(immunizationAdministered.supply()).toEqual null
+
+  describe "Order", ->
+    immunizationOrderedEntry = {
+        "_id":"5afc6ef608fa1813ddc09ffe",
+        "active_datetime":null,
+        "administrationTiming":null,
+        "allowedAdministrations":null,
+        "anatomical_approach":null,
+        "codes":{"CVX":["135"]},
+        "cumulativeMedicationDuration":null,
+        "deliveryMethod":null,
+        "description":"Immunization, Order: Influenza Vaccine",
+        "dose":{"scalar":"25","units":"mg"},
+        "doseIndicator":null,
+        "doseRestriction":null,
+        "end_time":null,
+        "freeTextSig":null,
+        "fulfillmentInstructions":null,
+        "health_record_field":null,
+        "indication":null,
+        "method":null,
+        "mood_code":"EVN",
+        "negationInd":true,
+        "negationReason":{"code_system":"SNOMED-CT","code":"128731000119101"},
+        "oid":null,
+        "patientInstructions":null,
+        "productForm":null,
+        "reaction":null,
+        "reason":{"code_system":"SNOMED-CT","code":"241935008","title":"Anaphylactic Reaction to Eggs"},
+        "refills":null,
+        "route":{"code_system":"SNOMED-CT","code":"185900003","title":"IMM2 Previous Receipt of Influenza Vaccine"},
+        "signed_datetime":null,
+        "specifics":null,
+        "start_time":1337155200,
+        "statusOfMedication":null,
+        "status_code":{"HL7 ActStatus":["ordered"]},
+        "supply":{"scalar":"27","units":"mg"},
+        "time":null,
+        "typeOfMedication":null,
+        "vehicle":null
+    }
+ 
+    it "should return an active DateTime", ->
+      immunizationOrdered = new CQL_QDM.ImmunizationOrder(immunizationOrderedEntry)
+      expect(immunizationOrdered.activeDatetime()).toEqual null
+
+    it "should return null if no active datetime is specified", ->
+      immunizationOrdered = new CQL_QDM.ImmunizationOrder({})
+      expect(immunizationOrdered.activeDatetime()).toEqual null
+
+    it "should return an author DateTime", ->
+      immunizationOrdered = new CQL_QDM.ImmunizationOrder(immunizationOrderedEntry)
+      expect(immunizationOrdered.authorDatetime()).toEqual new cql.DateTime(2012, 5, 16, 8, 0, 0, 0, 0)
+
+    it "should return null authorDateTime when no is start_time is specified", ->
+       immunizationOrdered = new CQL_QDM.ImmunizationOrder({})
+       expect(immunizationOrdered.authorDatetime()).toEqual null
+
+    it "should return a dosage quantity", ->
+      immunizationOrdered = new CQL_QDM.ImmunizationOrder(immunizationOrderedEntry)
+      expect(immunizationOrdered.dosage()).toEqual new cql.Quantity({unit: 'mg', value: '25'})
+
+    it "should return null if no dosage is specified", ->
+      immunizationOrdered = new CQL_QDM.ImmunizationOrder({})
+      expect(immunizationOrdered.dosage()).toEqual null
+
+    it "should return a negation rationale code", ->
+      immunizationOrdered = new CQL_QDM.ImmunizationOrder(immunizationOrderedEntry)
+      expect(immunizationOrdered.negationRationale()).toEqual new cql.Code('128731000119101', 'SNOMED-CT')
+
+    it "should return null if no negation rationale is specified", ->
+      immunizationOrdered = new CQL_QDM.ImmunizationOrder({})
+      expect(immunizationOrdered.negationRationale()).toEqual null
+
+    it "should return a reason code", ->
+      immunizationOrdered = new CQL_QDM.ImmunizationOrder(immunizationOrderedEntry)
+      expect(immunizationOrdered.reason()).toEqual new cql.Code('241935008', 'SNOMED-CT')
+
+    it "should return null if no reason is specified", ->
+      immunizationOrdered = new CQL_QDM.ImmunizationOrder({})
+      expect(immunizationOrdered.reason()).toEqual null
+
+    it "should return a route code", ->
+      immunizationOrdered = new CQL_QDM.ImmunizationOrder(immunizationOrderedEntry)
+      expect(immunizationOrdered.route()).toEqual new cql.Code('185900003', 'SNOMED-CT')
+
+    it "should return null if no route is specified", ->
+      immunizationOrdered = new CQL_QDM.ImmunizationOrder({})
+      expect(immunizationOrdered.route()).toEqual null
+
+    it "should return a supply quantity", ->
+      immunizationOrdered = new CQL_QDM.ImmunizationOrder(immunizationOrderedEntry)
+      expect(immunizationOrdered.supply()).toEqual new cql.Quantity({unit: 'mg', value: '27'})
+
+    it "should return null if no supply is specified", ->
+      immunizationOrdered = new CQL_QDM.ImmunizationOrder({})
+      expect(immunizationOrdered.supply()).toEqual null

--- a/spec/javascripts/datatypes/laboratory_test_spec.js.coffee
+++ b/spec/javascripts/datatypes/laboratory_test_spec.js.coffee
@@ -61,9 +61,10 @@ describe "Laboratory Test", ->
        laboratoryTestPerformed = new CQL_QDM.LaboratoryTestPerformed({})
        expect(laboratoryTestPerformed.authorDatetime()).toEqual null
 
-    # it "should return a method Code", ->
-    #    laboratoryTestPerformed = new CQL_QDM.LaboratoryTestPerformed(laboratoryTestPerformedEntry)
-    #    expect(laboratoryTestPerformed.method()).toEqual 'something'
+    # TODO: Add method attribute to laboratoryTestPerformed
+    xit "should return a method Code", ->
+       laboratoryTestPerformed = new CQL_QDM.LaboratoryTestPerformed(laboratoryTestPerformedEntry)
+       expect(laboratoryTestPerformed.method()).toEqual 'something'
 
     it "should return null if no method is specified", ->
        laboratoryTestPerformed = new CQL_QDM.LaboratoryTestPerformed({})
@@ -82,9 +83,9 @@ describe "Laboratory Test", ->
       expect(laboratoryTestPerformed.reason()).toEqual null
 
     # TODO: Implement test once referencerange low and high have been changed to hash type in HDS model lab_result.rb
-    # it "should return a reference range low quantity", ->
-    #   laboratoryTestPerformed = new CQL_QDM.LaboratoryTestPerformed(laboratoryTestPerformedEntry)
-    #   expect(laboratoryTestPerformed.referenceRange()).toEqual new cql.Interval(1,2)
+    xit "should return a reference range low quantity", ->
+      laboratoryTestPerformed = new CQL_QDM.LaboratoryTestPerformed(laboratoryTestPerformedEntry)
+      expect(laboratoryTestPerformed.referenceRange()).toEqual new cql.Interval(1,2)
 
     it "should return null if no reference range is specified ", ->
       laboratoryTestPerformed = new CQL_QDM.LaboratoryTestPerformed({})
@@ -114,9 +115,10 @@ describe "Laboratory Test", ->
       laboratoryTestPerformed = new CQL_QDM.LaboratoryTestPerformed({})
       expect(laboratoryTestPerformed.resultDatetime()).toEqual null
 
-    # it "should return a status code", ->
-    #   laboratoryTestPerformed = new CQL_QDM.LaboratoryTestPerformed(laboratoryTestPerformedEntry)
-    #   expect(laboratoryTestPerformed.status()).toEqual new cql.Code()
+    # TODO: Change source or status code in labratorytest.js.coffee
+    xit "should return a status code", ->
+      laboratoryTestPerformed = new CQL_QDM.LaboratoryTestPerformed(laboratoryTestPerformedEntry)
+      expect(laboratoryTestPerformed.status()).toEqual new cql.Code()
 
     it "should return null if no status is specified", ->
       laboratoryTestPerformed = new CQL_QDM.LaboratoryTestPerformed({})

--- a/spec/javascripts/datatypes/laboratory_test_spec.js.coffee
+++ b/spec/javascripts/datatypes/laboratory_test_spec.js.coffee
@@ -27,6 +27,32 @@ describe "Laboratory Test", ->
       "values":[{"_id":"5afc788b08fa1813ddc0a04e","codes":{"CDC Race":["2135-2"]},"description":"Ethnicity"}]
     }
 
+    laboratoryTestPerformedEntryTwoComponents = { 
+      "_id":"5b0d4cec92d04eda90d60f10",
+      "codes":{"LOINC":["34714-6"]},
+      "components":{"type":"COL","values":[{"code":{"code_system":"SNOMED-CT","code":"195080001"},"result":{"code":{"code_system":"SNOMED-CT","code":"419099009"},"title":"Dead"},"referenceRangeLow":{"scalar":"12","units":"mg"},"referenceRangeHigh":{"scalar":"14","units":"mg"}},{"code":{"code_system":"SNOMED-CT","code":"195080001"},"result":{"scalar":"15","units":"mg"},"referenceRangeLow":{"scalar":"12","units":"mg"},"referenceRangeHigh":{"scalar":"14","units":"mg"}}]},
+      "description":"Laboratory Test, Performed: INR",
+      "end_time":1338279300,
+      "health_record_field":null,
+      "interpretation":null,
+      "method":null,
+      "mood_code":"EVN",
+      "negationInd":null,
+      "negationReason":null,
+      "oid":"2.16.840.1.113883.3.560.1.5",
+      "qdm_status":null,
+      "reaction":null,
+      "reason":null,
+      "referenceRange":null,
+      "referenceRangeHigh":null,
+      "referenceRangeLow":null,
+      "result_date_time":null,
+      "specifics":null,
+      "start_time":1338278400,
+      "status_code":{"HL7 ActStatus":["performed"]},
+      "time":null
+    }
+
     it "should return an author DateTime", ->
       laboratoryTestPerformed = new CQL_QDM.LaboratoryTestPerformed(laboratoryTestPerformedEntry)
       expect(laboratoryTestPerformed.authorDatetime()).toEqual new cql.DateTime(2012, 5, 16, 8, 0, 0, 0, 0)
@@ -55,7 +81,8 @@ describe "Laboratory Test", ->
       laboratoryTestPerformed = new CQL_QDM.LaboratoryTestPerformed({})
       expect(laboratoryTestPerformed.reason()).toEqual null
 
-    # it "should return a reference range interval", ->
+    # TODO: Implement test once referencerange low and high have been changed to hash type in HDS model lab_result.rb
+    # it "should return a reference range low quantity", ->
     #   laboratoryTestPerformed = new CQL_QDM.LaboratoryTestPerformed(laboratoryTestPerformedEntry)
     #   expect(laboratoryTestPerformed.referenceRange()).toEqual new cql.Interval(1,2)
 
@@ -103,17 +130,13 @@ describe "Laboratory Test", ->
       laboratoryTestPerformed = new CQL_QDM.LaboratoryTestPerformed({})
       expect(JSON.stringify(laboratoryTestPerformed.components())).toEqual "[]"
 
-    it "should show just a single Component", ->
-      laboratoryTestPerformed = new CQL_QDM.LaboratoryTestPerformed({'components': {"type":"COL","values":[{"code":{"code_system":"ICD-10-PCS","code":"0270346"},"result":{"scalar":"1","units":""},"referenceRangeLow":{"scalar":"","units":""},"referenceRangeHigh":{"scalar":"","units":""}}]}})
-      expect(JSON.stringify(laboratoryTestPerformed.components())).toEqual '[{"_result":1,"_code":{"code":"0270346","system":"ICD-10-PCS"}}]'
-
     it "should show two Components", ->
-      laboratoryTestPerformed = new CQL_QDM.LaboratoryTestPerformed({'components': {"type":"COL","values":[{"code":{"code_system":"ICD-10-PCS","code":"0270346"},"result":{"scalar":"1","units":""},"referenceRangeLow":{"scalar":"","units":""},"referenceRangeHigh":{"scalar":"","units":""}},{"code":{"code_system":"Source of Payment Typology","code":"1"},"result":{"scalar":"1","units":""},"referenceRangeLow":{"scalar":"","units":""},"referenceRangeHigh":{"scalar":"","units":""}}]}})
-      expect(JSON.stringify(laboratoryTestPerformed.components())).toEqual '[{"_result":1,"_code":{"code":"0270346","system":"ICD-10-PCS"}},{"_result":1,"_code":{"code":"1","system":"Source of Payment Typology"}}]'
+      laboratoryTestPerformed = new CQL_QDM.LaboratoryTestPerformed(laboratoryTestPerformedEntryTwoComponents)
+      expect(JSON.stringify(laboratoryTestPerformed.components())).toEqual '[{"_result":{"code":"419099009","system":"SNOMED-CT"},"_code":{"code":"195080001","system":"SNOMED-CT"},"_referenceRange":{"low":"12","high":"14","lowClosed":true,"highClosed":true}},{"_result":{"unit":"mg","value":15},"_code":{"code":"195080001","system":"SNOMED-CT"},"_referenceRange":{"low":"12","high":"14","lowClosed":true,"highClosed":true}}]'
 
     it "should show Component with referenceRange low and high with units", ->
-      laboratoryTestPerformed = new CQL_QDM.LaboratoryTestPerformed({'components': {"type":"COL","values":[{"code":{"code_system":"ICD-10-PCS","code":"0270346"},"result":{"scalar":"2","units":"mg"},"referenceRangeLow":{"scalar":"1","units":"mg"},"referenceRangeHigh":{"scalar":"3","units":"mg"}}]}})
-      expect(JSON.stringify(laboratoryTestPerformed.components())).toEqual '[{"_result":{"unit":"mg","value":2},"_code":{"code":"0270346","system":"ICD-10-PCS"},"_referenceRange":{"low":"1","high":"3","lowClosed":true,"highClosed":true}}]'
+      laboratoryTestPerformed = new CQL_QDM.LaboratoryTestPerformed(laboratoryTestPerformedEntryTwoComponents)
+      expect(JSON.stringify(laboratoryTestPerformed.components()[1])).toEqual '{"_result":{"unit":"mg","value":15},"_code":{"code":"195080001","system":"SNOMED-CT"},"_referenceRange":{"low":"12","high":"14","lowClosed":true,"highClosed":true}}'
 
     it "should show Component with referenceRange low and high without units", ->
       laboratoryTestPerformed = new CQL_QDM.LaboratoryTestPerformed({'components': {"type":"COL","values":[{"code":{"code_system":"ICD-10-PCS","code":"0270346"},"result":{"scalar":"2","units":""},"referenceRangeLow":{"scalar":"1","units":""},"referenceRangeHigh":{"scalar":"3","units":""}}]}})
@@ -140,6 +163,5 @@ describe "Laboratory Test", ->
       expect(JSON.stringify(laboratoryTestPerformed.result())).toEqual('null')
 
     it "should return a result", ->
-      laboratoryTestPerformed = new CQL_QDM.LaboratoryTestPerformed({'values': [
-          {_id: "5aabbc4692d04e71f32f7619", codes: { 'SNOMED-CT': ["164059009"]}, description: "Pass Or Refer"}]})
-      expect(JSON.stringify(laboratoryTestPerformed.result())).toEqual('{"code":"164059009","system":"SNOMED-CT"}')
+      laboratoryTestPerformed = new CQL_QDM.LaboratoryTestPerformed(laboratoryTestPerformedEntry)
+      expect(JSON.stringify(laboratoryTestPerformed.result())).toEqual('{"code":"2135-2","system":"CDC Race"}')

--- a/spec/javascripts/datatypes/laboratory_test_spec.js.coffee
+++ b/spec/javascripts/datatypes/laboratory_test_spec.js.coffee
@@ -1,5 +1,104 @@
 describe "Laboratory Test", ->
   describe "Performed", ->
+    laboratoryTestPerformedEntry = {
+      "_id":"5afc788b08fa1813ddc0a04d",
+      "codes":{"LOINC":["34714-6"]},
+      "components":{"type":"COL","values":[{"code":{"code_system":"ICD-10-PCS","code":"0SQ90ZZ"},"result":{"code":{"code_system":"SNOMED-CT","code":"309904001"},"title":"Intensive Care Unit"},"referenceRangeLow":{"scalar":"23","units":"mg"},"referenceRangeHigh":{"scalar":"35","units":"mg"}}]},
+      "description":"Laboratory Test, Performed: INR",
+      "end_time":1337156100,
+      "health_record_field":null,
+      "interpretation":null,
+      "method":null,
+      "mood_code":"EVN",
+      "negationInd":null,
+      "negationReason":null,
+      "oid":"2.16.840.1.113883.3.560.1.5",
+      "qdm_status":{"code_system":"ICD-10-PCS","code":"0T1307B","title":"Urological Surgery"},
+      "reaction":null,
+      "reason":{"code_system":"ICD-10-PCS","code":"0QPD0JZ","title":"Knee Replacement Surgery"},
+      "referenceRange":null,
+      "referenceRangeHigh":"{\"scalar\"=>\"35\", \"units\"=>\"mg\"}",
+      "referenceRangeLow":"{\"scalar\"=>\"23\", \"units\"=>\"mg\"}",
+      "result_date_time":491126400,
+      "specifics":null,
+      "start_time":1337155200,
+      "status_code":{"HL7 ActStatus":["performed"]},
+      "time":null,
+      "values":[{"_id":"5afc788b08fa1813ddc0a04e","codes":{"CDC Race":["2135-2"]},"description":"Ethnicity"}]
+    }
+
+    it "should return an author DateTime", ->
+      laboratoryTestPerformed = new CQL_QDM.LaboratoryTestPerformed(laboratoryTestPerformedEntry)
+      expect(laboratoryTestPerformed.authorDatetime()).toEqual new cql.DateTime(2012, 5, 16, 8, 0, 0, 0, 0)
+
+    it "should return null authorDateTime when no is start_time is specified", ->
+       laboratoryTestPerformed = new CQL_QDM.LaboratoryTestPerformed({})
+       expect(laboratoryTestPerformed.authorDatetime()).toEqual null
+
+    # it "should return a method Code", ->
+    #    laboratoryTestPerformed = new CQL_QDM.LaboratoryTestPerformed(laboratoryTestPerformedEntry)
+    #    expect(laboratoryTestPerformed.method()).toEqual 'something'
+
+    it "should return null if no method is specified", ->
+       laboratoryTestPerformed = new CQL_QDM.LaboratoryTestPerformed({})
+       expect(laboratoryTestPerformed.method()).toEqual null
+
+    it "should return null if no negation rationale is specified", ->
+      laboratoryTestPerformed = new CQL_QDM.LaboratoryTestPerformed({})
+      expect(laboratoryTestPerformed.negationRationale()).toEqual null
+
+    it "should return a reason code", ->
+      laboratoryTestPerformed = new CQL_QDM.LaboratoryTestPerformed(laboratoryTestPerformedEntry)
+      expect(laboratoryTestPerformed.reason()).toEqual new cql.Code('0QPD0JZ', 'ICD-10-PCS')
+
+    it "should return null if no reason is specified", ->
+      laboratoryTestPerformed = new CQL_QDM.LaboratoryTestPerformed({})
+      expect(laboratoryTestPerformed.reason()).toEqual null
+
+    # it "should return a reference range interval", ->
+    #   laboratoryTestPerformed = new CQL_QDM.LaboratoryTestPerformed(laboratoryTestPerformedEntry)
+    #   expect(laboratoryTestPerformed.referenceRange()).toEqual new cql.Interval(1,2)
+
+    it "should return null if no reference range is specified ", ->
+      laboratoryTestPerformed = new CQL_QDM.LaboratoryTestPerformed({})
+      expect(laboratoryTestPerformed.referenceRange()).toEqual null
+
+    it "should return a relevantPeriod interval", ->
+      laboratoryTestPerformed = new CQL_QDM.LaboratoryTestPerformed(laboratoryTestPerformedEntry)
+      expect(laboratoryTestPerformed.relevantPeriod()).toEqual new cql.Interval(new cql.DateTime(2012, 5, 16, 8, 0, 0, 0, 0), new cql.DateTime(2012, 5, 16, 8, 15, 0, 0, 0))
+
+    it "should return null if no relevant period is specified ", ->
+      laboratoryTestPerformed = new CQL_QDM.LaboratoryTestPerformed({})
+      expect(laboratoryTestPerformed.relevantPeriod()).toEqual null
+
+    it "should return a result object", ->
+      laboratoryTestPerformed = new CQL_QDM.LaboratoryTestPerformed(laboratoryTestPerformedEntry)
+      expect(laboratoryTestPerformed.result()).toEqual new cql.Code('2135-2', 'CDC Race')
+
+    it "should return null if no result is specified ", ->
+      laboratoryTestPerformed = new CQL_QDM.LaboratoryTestPerformed({})
+      expect(laboratoryTestPerformed.result()).toEqual null
+
+    it "should return resultDatetime", ->
+      laboratoryTestPerformed = new CQL_QDM.LaboratoryTestPerformed(laboratoryTestPerformedEntry)
+      expect(laboratoryTestPerformed.resultDatetime()).toEqual new cql.DateTime(1985, 7, 25, 8, 0, 0, 0, 0)
+
+    it "should return null if no resultDatetime", ->
+      laboratoryTestPerformed = new CQL_QDM.LaboratoryTestPerformed({})
+      expect(laboratoryTestPerformed.resultDatetime()).toEqual null
+
+    # it "should return a status code", ->
+    #   laboratoryTestPerformed = new CQL_QDM.LaboratoryTestPerformed(laboratoryTestPerformedEntry)
+    #   expect(laboratoryTestPerformed.status()).toEqual new cql.Code()
+
+    it "should return null if no status is specified", ->
+      laboratoryTestPerformed = new CQL_QDM.LaboratoryTestPerformed({})
+      expect(laboratoryTestPerformed.status()).toEqual null
+
+    it "should return a component", ->
+      laboratoryTestPerformed = new CQL_QDM.LaboratoryTestPerformed(laboratoryTestPerformedEntry)
+      expect(JSON.stringify(laboratoryTestPerformed.components())).toEqual '[{"_result":{"code":"309904001","system":"SNOMED-CT"},"_code":{"code":"0SQ90ZZ","system":"ICD-10-PCS"},"_referenceRange":{"low":"23","high":"35","lowClosed":true,"highClosed":true}}]'
+
     it "should show nothing if there is no Component", ->
       laboratoryTestPerformed = new CQL_QDM.LaboratoryTestPerformed({})
       expect(JSON.stringify(laboratoryTestPerformed.components())).toEqual "[]"
@@ -29,11 +128,11 @@ describe "Laboratory Test", ->
       expect(JSON.stringify(laboratoryTestPerformed.components())).toEqual '[{"_result":2,"_code":{"code":"0270346","system":"ICD-10-PCS"},"_referenceRange":{"high":"3","lowClosed":true,"highClosed":true}}]'
 
     it "should show null relevantPeriod", ->
-      laboratoryTestPerformed = new CQL_QDM.AdverseEvent({})
+      laboratoryTestPerformed = new CQL_QDM.LaboratoryTestPerformed({})
       expect(laboratoryTestPerformed.relevantPeriod()).toBeNull()
 
     it "should show valid relevantPeriod", ->
-      laboratoryTestPerformed = new CQL_QDM.AdverseEvent({'start_time': '08/31/2017 1:00 AM', 'end_time': '08/31/2017 2:00 AM'})
+      laboratoryTestPerformed = new CQL_QDM.LaboratoryTestPerformed({'start_time': '08/31/2017 1:00 AM', 'end_time': '08/31/2017 2:00 AM'})
       expect(JSON.stringify(laboratoryTestPerformed.relevantPeriod())).toEqual '{"low":"2017-08-31T01:00:00.000+00:00","high":"2017-08-31T02:00:00.000+00:00","lowClosed":true,"highClosed":true}'
 
     it "should not return a result", ->

--- a/spec/javascripts/datatypes/medication_spec.js.coffee
+++ b/spec/javascripts/datatypes/medication_spec.js.coffee
@@ -259,6 +259,10 @@ describe "Medication", ->
       medicationActive = new CQL_QDM.MedicationActive(medicationActiveEntry)
       expect(medicationActive.route()).toEqual new cql.Code('995218', 'RxNorm')
 
+    it "should return a supply quantity", ->
+      medicationActive = new CQL_QDM.MedicationActive(medicationActiveEntry)
+      expect(medicationActive.supply()).toEqual new cql.Quantity({unit: 'g', value: '1000'})
+
     it "should return null when field is not on constructing entry", ->
       medicationActive = new CQL_QDM.MedicationActive({'start_time': '08/31/2017 1:00 AM', 'end_time': '08/31/2017 2:00 AM'})
       expect(medicationActive.frequency()).toEqual null
@@ -414,6 +418,10 @@ describe "Medication", ->
     it "should return an integer of the number of refills", ->
       medicationDispensed = new CQL_QDM.MedicationDischarge(medicationDischargeEntry)
       expect(medicationDispensed.refills()).toEqual '100'
+
+    it "should return a supply quantity", ->
+      medicationDispensed = new CQL_QDM.MedicationDischarge(medicationDischargeEntry)
+      expect(medicationDispensed.supply()).toEqual new cql.Quantity({unit: 'mg', value: '100'})
 
     it "should return null when field is not on constructing entry", ->
       medicationDischarge = new CQL_QDM.MedicationDischarge({'start_time': '08/31/2017 1:00 AM', 'end_time': '08/31/2017 2:00 AM'})

--- a/spec/javascripts/datatypes/medication_spec.js.coffee
+++ b/spec/javascripts/datatypes/medication_spec.js.coffee
@@ -1,38 +1,93 @@
 describe "Medication", ->
   describe "Dispensed", ->
-    it "can be created and simple accessor works", ->
-      medicationDispensed = new CQL_QDM.MedicationDispensed({'supply': {unit: 'g', scalar: 5}})
-      expect(medicationDispensed.supply()).toEqual new cql.Quantity({unit: 'g', value: 5})
+    medicationDispensedEntry ={
+      "_id":"5b06a00692d04ea74456b2b9",
+      "active_datetime":null,
+      "administrationTiming":{"code_system":"LOINC","code":"29463-7","title":"Body Weight"},
+      "allowedAdministrations":null,
+      "anatomical_approach":null,
+      "codes":{"RxNorm":["1010600"]},
+      "cumulativeMedicationDuration":null,
+      "deliveryMethod":null,
+      "description":"Medication, Dispensed: Opioid Pain Medications",
+      "dose":{"scalar":"100","units":"g"},
+      "doseIndicator":null,
+      "doseRestriction":null,
+      "end_time":1337683600,
+      "freeTextSig":null,
+      "fulfillmentHistory":[],
+      "fulfillmentInstructions":null,
+      "health_record_field":{"code_system":"RxNorm","code":"1002293","title":"Common substances for allergy and intolerance documentation"},
+      "indication":null,
+      "method":null,
+      "mood_code":"EVN",
+      "negationInd":true,
+      "negationReason":{"code_system":"SNOMED-CT","code":"10725009"},
+      "oid":"2.16.840.1.113883.3.560.1.108",
+      "patientInstructions":null,
+      "productForm":null,
+      "reaction":{"code_system":"LOINC","code":"29463-7","title":"Body Weight"},
+      "reason":{"code_system":"RxNorm","code":"995218","title":"Hydroxyzine"},
+      "references":[{"_id":"5b06a00692d04ea74456b2ba","referenced_id":"5b06a00692d04ea74456b2b8","referenced_type":"Medication","type":"Related To"}],
+      "refills":{"scalar":"3","units":""},
+      "route":{"code_system":"LOINC","code":"29463-7","title":"Body Weight"},
+      "signed_datetime":null,
+      "specifics":null,
+      "start_time":1337673600,
+      "statusOfMedication":null,
+      "status_code":{"HL7 ActStatus":["dispensed"]},
+      "supply":{"scalar":"10","units":"g"},
+      "time":null,
+      "typeOfMedication":null,
+      "vehicle":null
+    }
 
     it "has revelantPeriod", ->
-      medicationDispensed = new CQL_QDM.MedicationDispensed({'start_time':'03/17/2012 10:17 AM', 'end_time':'03/17/2012 10:32 AM'})
-      expect(medicationDispensed.relevantPeriod().low).toEqual new cql.DateTime(2012, 3, 17, 10, 17, 0, 0, 0)
-      expect(medicationDispensed.relevantPeriod().high).toEqual new cql.DateTime(2012, 3, 17, 10, 32, 0, 0, 0)
+      medicationDispensed = new CQL_QDM.MedicationDispensed(medicationDispensedEntry)
+      expect(medicationDispensed.relevantPeriod().low).toEqual new cql.DateTime(2012, 5, 22, 8, 0, 0, 0, 0)
+      expect(medicationDispensed.relevantPeriod().high).toEqual new cql.DateTime(2012, 5, 22, 10, 46, 40, 0, 0)
 
     it "has infinite DateTime when no end_time specified", ->
-      medicationDispensed = new CQL_QDM.MedicationDispensed({'start_time':'03/17/2012 10:17 AM'})
-      expect(medicationDispensed.relevantPeriod().low).toEqual new cql.DateTime(2012, 3, 17, 10, 17, 0, 0, 0)
+      previous_end_time = medicationDispensedEntry['end_time']
+      # Set end_time to null so that end_time is not specified in this test
+      medicationDispensedEntry['end_time'] = null
+      medicationDispensed = new CQL_QDM.MedicationDispensed(medicationDispensedEntry)
+      expect(medicationDispensed.relevantPeriod().low).toEqual new cql.DateTime(2012, 5, 22, 8, 0, 0, 0, 0)
       expect(medicationDispensed.relevantPeriod().high).toEqual CQL_QDM.Helpers.infinityDateTime()
+      # Reset end_time in fixture so that other tests arent effected
+      medicationDispensedEntry['end_time'] = previous_end_time
 
     it "should show null relevantPeriod", ->
       medicationDispensed = new CQL_QDM.MedicationDispensed({})
       expect(medicationDispensed.relevantPeriod()).toBeNull()
 
     it "should show valid relevantPeriod", ->
-      medicationDispensed = new CQL_QDM.MedicationDispensed({'start_time': '08/31/2017 1:00 AM', 'end_time': '08/31/2017 2:00 AM'})
-      expect(JSON.stringify(medicationDispensed.relevantPeriod())).toEqual '{"low":"2017-08-31T01:00:00.000+00:00","high":"2017-08-31T02:00:00.000+00:00","lowClosed":true,"highClosed":true}'
+      medicationDispensed = new CQL_QDM.MedicationDispensed(medicationDispensedEntry)
+      expect(JSON.stringify(medicationDispensed.relevantPeriod())).toEqual '{"low":"2012-05-22T08:00:00.000+00:00","high":"2012-05-22T10:46:40.000+00:00","lowClosed":true,"highClosed":true}'
 
     it "should return an integer of the number of refills", ->
-      medicationDispensed = new CQL_QDM.MedicationDispensed({'start_time': '08/31/2017 1:00 AM', 'end_time': '08/31/2017 2:00 AM', 'refills': {unit: '', scalar: 5}})
-      expect(medicationDispensed.refills()).toEqual 5
+      medicationDispensed = new CQL_QDM.MedicationDispensed(medicationDispensedEntry)
+      expect(medicationDispensed.refills()).toEqual '3'
 
     it "should return a coded frequency", ->
-      medicationDispensed = new CQL_QDM.MedicationDispensed({'administrationTiming': {code: '1234', code_system: 'SNOMED-CT', version: '', title: 'Test Code'}})
-      expect(medicationDispensed.frequency()).toEqual new cql.Code('1234', 'SNOMED-CT', '', 'Test Code')
+      medicationDispensed = new CQL_QDM.MedicationDispensed(medicationDispensedEntry)
+      expect(medicationDispensed.frequency()).toEqual new cql.Code('29463-7', 'LOINC')
 
     it "should return a dosage quantity", ->
-      medicationDispensed = new CQL_QDM.MedicationDispensed({'dose': {unit: 'g', scalar: 10}})
-      expect(medicationDispensed.dosage()).toEqual new cql.Quantity({unit: 'g', value: 10})
+      medicationDispensed = new CQL_QDM.MedicationDispensed(medicationDispensedEntry)
+      expect(medicationDispensed.dosage()).toEqual new cql.Quantity({unit: 'g', value: 100})
+
+    it "should return a negation rationale code", ->
+      medicationDispensed = new CQL_QDM.MedicationDispensed(medicationDispensedEntry)
+      expect(medicationDispensed.negationRationale()).toEqual new cql.Code('10725009', 'SNOMED-CT')
+
+    it "should return a route code", ->
+      medicationDispensed = new CQL_QDM.MedicationDispensed(medicationDispensedEntry)
+      expect(medicationDispensed.route()).toEqual new cql.Code('29463-7', 'LOINC')
+
+    it "should return a supply quantity", ->
+      medicationDispensed = new CQL_QDM.MedicationDispensed(medicationDispensedEntry)
+      expect(medicationDispensed.supply()).toEqual new cql.Quantity({unit: 'g', value: '10'})
 
     it "should return null when field is not on constructing entry", ->
       medicationDispensed = new CQL_QDM.MedicationDispensed({'start_time': '08/31/2017 1:00 AM', 'end_time': '08/31/2017 2:00 AM'})
@@ -40,42 +95,98 @@ describe "Medication", ->
       expect(medicationDispensed.refills()).toEqual null
       expect(medicationDispensed.supply()).toEqual null
       expect(medicationDispensed.dosage()).toEqual null
-
+      expect(medicationDispensed.route()).toEqual null
+      expect(medicationDispensed.negationRationale()).toEqual null
 
   describe "Order", ->
-    it "can be created and simple accessor works", ->
-      medicationOrdered = new CQL_QDM.MedicationOrder({'supply': {unit: 'g', scalar: 5}})
-      expect(medicationOrdered.supply()).toEqual new cql.Quantity({unit: 'g', value: 5})
+    medicationOrderEntry = {
+      "_id":"5b06bb4d92d04ea74456b327",
+      "active_datetime":null,
+      "administrationTiming":{"code_system":"RxNorm","code":"1002293","title":"Common substances for allergy and intolerance documentation"},
+      "allowedAdministrations":null,
+      "anatomical_approach":null,
+      "codes":{"RxNorm":["1010600"]},
+      "cumulativeMedicationDuration":null,
+      "deliveryMethod":null,
+      "description":"Medication, Order: Opioid Pain Medications",
+      "dose":{"scalar":"100","units":"mg"},
+      "doseIndicator":null,
+      "doseRestriction":null,
+      "end_time":1337846400,
+      "freeTextSig":null,
+      "fulfillmentHistory":[],
+      "fulfillmentInstructions":null,
+      "health_record_field":{"code_system":"LOINC","code":"29463-7","title":"Body Weight"},
+      "indication":null,
+      "method":null,
+      "mood_code":"EVN",
+      "negationInd":true,
+      "negationReason":{"code_system":"RxNorm","code":"1002293"},
+      "oid":"2.16.840.1.113883.3.560.1.78",
+      "patientInstructions":null,
+      "productForm":null,
+      "reaction":{"code_system":"LOINC","code":"29463-7","title":"Body Weight"},
+      "reason":{"code_system":"RxNorm","code":"995218","title":"Hydroxyzine"},
+      "refills":{"scalar":"33","units":""},
+      "route":{"code_system":"LOINC","code":"29463-7","title":"Body Weight"},
+      "signed_datetime":null,
+      "specifics":null,
+      "start_time":1337846400,
+      "statusOfMedication":null,
+      "status_code":{"HL7 ActStatus":["ordered"]},
+      "supply":{"scalar":"10","units":"mg"},
+      "time":null,
+      "typeOfMedication":null,
+      "vehicle":null
+    }
 
     it "has revelantPeriod", ->
-      medicationOrdered = new CQL_QDM.MedicationOrder({'start_time':'02/21/2012 03:03 AM', 'end_time':'02/22/2012 05:00 PM'})
-      expect(medicationOrdered.relevantPeriod().low).toEqual new cql.DateTime(2012, 2, 21, 3, 3, 0, 0, 0)
-      expect(medicationOrdered.relevantPeriod().high).toEqual new cql.DateTime(2012, 2, 22, 17, 0, 0, 0, 0)
+      medicationOrdered = new CQL_QDM.MedicationOrder(medicationOrderEntry)
+      expect(medicationOrdered.relevantPeriod().low).toEqual new cql.DateTime(2012, 5, 24, 8, 0, 0, 0, 0)
+      expect(medicationOrdered.relevantPeriod().high).toEqual new cql.DateTime(2012, 5, 24, 8, 0, 0, 0, 0)
 
     it "has infinite DateTime when no end_time specified", ->
-      medicationOrdered = new CQL_QDM.MedicationOrder({'start_time':'02/21/2012 03:03 AM'})
-      expect(medicationOrdered.relevantPeriod().low).toEqual new cql.DateTime(2012, 2, 21, 3, 3, 0, 0, 0)
+      previous_end_time = medicationOrderEntry['end_time']
+      # Set end_time to null so that end_time is not specified in this test
+      medicationOrderEntry['end_time'] = null
+      medicationOrdered = new CQL_QDM.MedicationOrder(medicationOrderEntry)
+      expect(medicationOrdered.relevantPeriod().low).toEqual new cql.DateTime(2012, 5, 24, 8, 0, 0, 0, 0)
       expect(medicationOrdered.relevantPeriod().high).toEqual CQL_QDM.Helpers.infinityDateTime()
+      # Reset end_time in fixture so that other tests arent effected
+      medicationOrderEntry['end_time'] = previous_end_time
 
     it "should show null relevantPeriod", ->
       medicationOrdered = new CQL_QDM.MedicationOrder({})
       expect(medicationOrdered.relevantPeriod()).toBeNull()
 
     it "should show valid relevantPeriod", ->
-      medicationOrdered = new CQL_QDM.MedicationOrder({'start_time': '08/31/2017 1:00 AM', 'end_time': '08/31/2017 2:00 AM'})
-      expect(JSON.stringify(medicationOrdered.relevantPeriod())).toEqual '{"low":"2017-08-31T01:00:00.000+00:00","high":"2017-08-31T02:00:00.000+00:00","lowClosed":true,"highClosed":true}'
+      medicationOrdered = new CQL_QDM.MedicationOrder(medicationOrderEntry)
+      expect(JSON.stringify(medicationOrdered.relevantPeriod())).toEqual '{"low":"2012-05-24T08:00:00.000+00:00","high":"2012-05-24T08:00:00.000+00:00","lowClosed":true,"highClosed":true}'
 
     it "should return an integer of the number of refills", ->
-      medicationOrdered = new CQL_QDM.MedicationOrder({'start_time': '08/31/2017 1:00 AM', 'end_time': '08/31/2017 2:00 AM', 'refills': {unit: '', scalar: 5}})
-      expect(medicationOrdered.refills()).toEqual 5
+      medicationOrdered = new CQL_QDM.MedicationOrder(medicationOrderEntry)
+      expect(medicationOrdered.refills()).toEqual '33'
 
     it "should return a coded frequency", ->
-      medicationOrdered = new CQL_QDM.MedicationOrder({'administrationTiming': {code: '1234', code_system: 'SNOMED-CT', version: '', title: 'Test Code'}})
-      expect(medicationOrdered.frequency()).toEqual new cql.Code('1234', 'SNOMED-CT', '', 'Test Code')
+      medicationOrdered = new CQL_QDM.MedicationOrder(medicationOrderEntry)
+      expect(medicationOrdered.frequency()).toEqual new cql.Code('1002293', 'RxNorm')
 
     it "should return a dosage quantity", ->
-      medicationOrdered = new CQL_QDM.MedicationOrder({'dose': {unit: 'g', scalar: 10}})
-      expect(medicationOrdered.dosage()).toEqual new cql.Quantity({unit: 'g', value: 10})
+      medicationOrdered = new CQL_QDM.MedicationOrder(medicationOrderEntry)
+      expect(medicationOrdered.dosage()).toEqual new cql.Quantity({unit: 'mg', value: 100})
+
+    it "should return a negation rationale code", ->
+      medicationOrdered = new CQL_QDM.MedicationOrder(medicationOrderEntry)
+      expect(medicationOrdered.negationRationale()).toEqual new cql.Code('1002293', 'RxNorm')
+
+    it "should return a route code", ->
+      medicationOrdered = new CQL_QDM.MedicationOrder(medicationOrderEntry)
+      expect(medicationOrdered.route()).toEqual new cql.Code('29463-7', 'LOINC')
+
+    it "should return a supply quantity", ->
+      medicationOrdered = new CQL_QDM.MedicationOrder(medicationOrderEntry)
+      expect(medicationOrdered.supply()).toEqual new cql.Quantity({unit: 'mg', value: '10'})
+
 
     it "should return null when field is not on constructing entry", ->
       medicationOrdered = new CQL_QDM.MedicationOrder({'start_time': '08/31/2017 1:00 AM', 'end_time': '08/31/2017 2:00 AM'})
@@ -83,65 +194,226 @@ describe "Medication", ->
       expect(medicationOrdered.refills()).toEqual null
       expect(medicationOrdered.supply()).toEqual null
       expect(medicationOrdered.dosage()).toEqual null
+      expect(medicationOrdered.route()).toEqual null
+      expect(medicationOrdered.negationRationale()).toEqual null
 
   describe "Active", ->
+    medicationActiveEntry = {
+      "_id":"5b06cc2592d04ea74456b38f",
+      "active_datetime":null,
+      "administrationTiming":{"code_system":"RxNorm","code":"1002293","title":"Common substances for allergy and intolerance documentation"},
+      "allowedAdministrations":null,
+      "anatomical_approach":null,
+      "codes":{"RxNorm":["995218"]},
+      "cumulativeMedicationDuration":null,
+      "deliveryMethod":null,
+      "description":"Medication, Active: Hydroxyzine",
+      "dose":{"scalar":"12","units":"mg"},
+      "doseIndicator":null,
+      "doseRestriction":null,
+      "end_time":1337847300,
+      "freeTextSig":null,
+      "fulfillmentHistory":[],
+      "fulfillmentInstructions":null,
+      "health_record_field":{"code_system":"RxNorm","code":"1002293","title":"Common substances for allergy and intolerance documentation"},
+      "indication":null,
+      "method":null,
+      "mood_code":"EVN",
+      "negationInd":null,
+      "negationReason":null,
+      "oid":"2.16.840.1.113883.3.560.1.13",
+      "patientInstructions":null,
+      "productForm":null,
+      "reaction":{"code_system":"LOINC","code":"29463-7","title":"Body Weight"},
+      "reason":{"code_system":"CDC Race","code":"2135-2","title":"Ethnicity"},
+      "refills":null,
+      "route":{"code_system":"RxNorm","code":"995218","title":"Hydroxyzine"},
+      "signed_datetime":null,
+      "specifics":null,
+      "start_time":1337846400,
+      "statusOfMedication":null,
+      "status_code":{"SNOMED-CT":["55561003"],"HL7 ActStatus":["active"]},
+      "supply":{"scalar":"1000","units":"g"},
+      "time":null,
+      "typeOfMedication":null,
+      "vehicle":null
+    }
+
     it "should show null relevantPeriod", ->
       medicationActive = new CQL_QDM.MedicationActive({})
       expect(medicationActive.relevantPeriod()).toBeNull()
 
     it "should show valid relevantPeriod", ->
-      medicationActive = new CQL_QDM.MedicationActive({'start_time': '08/31/2017 1:00 AM', 'end_time': '08/31/2017 2:00 AM'})
-      expect(JSON.stringify(medicationActive.relevantPeriod())).toEqual '{"low":"2017-08-31T01:00:00.000+00:00","high":"2017-08-31T02:00:00.000+00:00","lowClosed":true,"highClosed":true}'
+      medicationActive = new CQL_QDM.MedicationActive(medicationActiveEntry)
+      expect(JSON.stringify(medicationActive.relevantPeriod())).toEqual '{"low":"2012-05-24T08:00:00.000+00:00","high":"2012-05-24T08:15:00.000+00:00","lowClosed":true,"highClosed":true}'
+
+    it "should return a coded frequency", ->
+      medicationActive = new CQL_QDM.MedicationActive(medicationActiveEntry)
+      expect(medicationActive.frequency()).toEqual new cql.Code('1002293', 'RxNorm')
+
+    it "should return a dosage quantity", ->
+      medicationActive = new CQL_QDM.MedicationActive(medicationActiveEntry)
+      expect(medicationActive.dosage()).toEqual new cql.Quantity({unit: 'mg', value: 12})
+
+    it "should return a route code", ->
+      medicationActive = new CQL_QDM.MedicationActive(medicationActiveEntry)
+      expect(medicationActive.route()).toEqual new cql.Code('995218', 'RxNorm')
 
     it "should return null when field is not on constructing entry", ->
       medicationActive = new CQL_QDM.MedicationActive({'start_time': '08/31/2017 1:00 AM', 'end_time': '08/31/2017 2:00 AM'})
       expect(medicationActive.frequency()).toEqual null
       expect(medicationActive.dosage()).toEqual null
       expect(medicationActive.supply()).toEqual null
-      
-    it "should return a coded frequency", ->
-      medicationActive = new CQL_QDM.MedicationActive({'administrationTiming': {code: '1234', code_system: 'SNOMED-CT', version: '', title: 'Test Code'}})
-      expect(medicationActive.frequency()).toEqual new cql.Code('1234', 'SNOMED-CT', '', 'Test Code')
-      
-    it "should return a dosage quantity", ->
-      medicationActive = new CQL_QDM.MedicationActive({'dose': {unit: 'g', scalar: 10}})
-      expect(medicationActive.dosage()).toEqual new cql.Quantity({unit: 'g', value: 10})
 
   describe "Administered", ->
+    medicationAdministeredEntry ={
+      "_id":"5b046c2a92d04e9509d6c303",
+      "active_datetime":null,
+      "administrationTiming":{"code_system":"RxNorm","code":"1002293", "title":"Common substances for allergy and intolerance documentation"},
+      "allowedAdministrations":null,
+      "anatomical_approach":null,
+      "codes":{"RxNorm":["1010600"]},
+      "cumulativeMedicationDuration":null,
+      "deliveryMethod":null,
+      "description":"Medication, Administered: Opioid Pain Medications",
+      "dose":{"scalar":"10","units":"g"},
+      "doseIndicator":null,
+      "doseRestriction":null,
+      "end_time":1337674500,
+      "freeTextSig":null,
+      "fulfillmentHistory":[],
+      "fulfillmentInstructions":null,
+      "health_record_field":{"code_system":"RxNorm","code":"1010600","title":"Opioid Pain Medications"},
+      "indication":null,
+      "method":null,
+      "mood_code":"EVN",
+      "negationInd":true,
+      "negationReason":{"code_system":"SNOMED-CT","code":"10725009"},
+      "oid":"2.16.840.1.113883.3.560.1.14",
+      "patientInstructions":null,
+      "productForm":null,
+      "reaction":{"code_system":"LOINC","code":"29463-7","title":"Body Weight"},
+      "reason":{"code_system":"SNOMED-CT","code":"10725009","title":"Essential Hypertension"},
+      "references":[{"_id":"5b046c8392d04e9509d6c306","referenced_id":"5b046c8392d04e9509d6c307",
+      "referenced_type":"Medication","type":"Related To"}],
+      "refills":{"scalar":"3","units":""},
+      "route":{"code_system":"RxNorm","code":"1002293","title":"Common substances for allergy and intolerance documentation"},
+      "signed_datetime":null,
+      "specifics":null,
+      "start_time":1337673600,
+      "statusOfMedication":null,
+      "status_code":{"HL7 ActStatus":["administered"]},
+      "supply":{"scalar":"44","units":"mg"},
+      "time":null,
+      "typeOfMedication":null,
+      "vehicle":null
+    }
+
     it "should show null relevantPeriod", ->
       medicationAdministered = new CQL_QDM.MedicationAdministered({})
       expect(medicationAdministered.relevantPeriod()).toBeNull()
 
     it "should show valid relevantPeriod", ->
-      medicationAdministered = new CQL_QDM.MedicationAdministered({'start_time': '08/31/2017 1:00 AM', 'end_time': '08/31/2017 2:00 AM'})
-      expect(JSON.stringify(medicationAdministered.relevantPeriod())).toEqual '{"low":"2017-08-31T01:00:00.000+00:00","high":"2017-08-31T02:00:00.000+00:00","lowClosed":true,"highClosed":true}'
+      medicationAdministered = new CQL_QDM.MedicationAdministered(medicationAdministeredEntry)
+      expect(JSON.stringify(medicationAdministered.relevantPeriod())).toEqual '{"low":"2012-05-22T08:00:00.000+00:00","high":"2012-05-22T08:15:00.000+00:00","lowClosed":true,"highClosed":true}'
 
     it "should return a coded frequency", ->
-      medicationAdministered = new CQL_QDM.MedicationAdministered({'administrationTiming': {code: '1234', code_system: 'SNOMED-CT', version: '', title: 'Test Code'}})
-      expect(medicationAdministered.frequency()).toEqual new cql.Code('1234', 'SNOMED-CT', '', 'Test Code')
+      medicationAdministered = new CQL_QDM.MedicationAdministered(medicationAdministeredEntry)
+      expect(medicationAdministered.frequency()).toEqual new cql.Code('1002293', 'RxNorm')
 
     it "should return a dosage quantity", ->
-      medicationAdministered = new CQL_QDM.MedicationAdministered({'dose': {unit: 'g', scalar: 10}})
+      medicationAdministered = new CQL_QDM.MedicationAdministered(medicationAdministeredEntry)
       expect(medicationAdministered.dosage()).toEqual new cql.Quantity({unit: 'g', value: 10})
+
+    it "should return a negation rationale code", ->
+      medicationAdministered = new CQL_QDM.MedicationAdministered(medicationAdministeredEntry)
+      expect(medicationAdministered.negationRationale()).toEqual new cql.Code('10725009', 'SNOMED-CT')
+
+    it "should return a reason code", ->
+      medicationAdministered = new CQL_QDM.MedicationAdministered(medicationAdministeredEntry)
+      expect(medicationAdministered.reason()).toEqual new cql.Code('10725009', 'SNOMED-CT')
+
+    it "should return a route code", ->
+      medicationAdministered = new CQL_QDM.MedicationAdministered(medicationAdministeredEntry)
+      expect(medicationAdministered.route()).toEqual new cql.Code('1002293', 'RxNorm')
+
+    it "should return a supply quantity", ->
+      medicationAdministered = new CQL_QDM.MedicationAdministered(medicationAdministeredEntry)
+      expect(medicationAdministered.supply()).toEqual new cql.Quantity({unit: 'mg', value: '44'})
 
     it "should return null when field is not on constructing entry", ->
       medicationAdministered = new CQL_QDM.MedicationAdministered({'start_time': '08/31/2017 1:00 AM', 'end_time': '08/31/2017 2:00 AM'})
       expect(medicationAdministered.frequency()).toEqual null
       expect(medicationAdministered.supply()).toEqual null
       expect(medicationAdministered.dosage()).toEqual null
+      expect(medicationAdministered.route()).toEqual null
+      expect(medicationAdministered.reason()).toEqual null
+      expect(medicationAdministered.negationRationale()).toEqual null
 
   describe "Discharge", ->
+    medicationDischargeEntry = {
+      "_id":"5b06cf4892d04ea74456b3d7",
+      "active_datetime":null,
+      "administrationTiming":{"code_system":"SNOMED-CT","code":"10725009","title":"Essential Hypertension"},
+      "allowedAdministrations":null,
+      "anatomical_approach":null,
+      "codes":{"RxNorm":["1010600"]},
+      "cumulativeMedicationDuration":null,
+      "deliveryMethod":null,
+      "description":"Medication, Discharge: Opioid Pain Medications",
+      "dose":{"scalar":"100","units":"mg"},
+      "doseIndicator":null,
+      "doseRestriction":null,
+      "end_time":null,
+      "freeTextSig":null,
+      "fulfillmentHistory":[],
+      "fulfillmentInstructions":null,
+      "health_record_field":null,
+      "indication":null,
+      "method":null,
+      "mood_code":"EVN",
+      "negationInd":true,
+      "negationReason":{"code_system":"LOINC","code":"29463-7"},
+      "oid":"2.16.840.1.113883.3.560.1.200",
+      "patientInstructions":null,
+      "productForm":null,
+      "reaction":null,
+      "reason":null,
+      "refills":{"scalar":"100","units":""},
+      "route":{"code_system":"RxNorm","code":"995218","title":"Hydroxyzine"},
+      "signed_datetime":null,
+      "specifics":null,
+      "start_time":1337846400,
+      "statusOfMedication":null,
+      "status_code":{"HL7 ActStatus":["discharge"]},
+      "supply":{"scalar":"100","units":"mg"},
+      "time":null,
+      "typeOfMedication":null,
+      "vehicle":null
+    }
     it "should return a coded frequency", ->
-      medicationDischarge = new CQL_QDM.MedicationDischarge({'administrationTiming': {code: '1234', code_system: 'SNOMED-CT', version: '', title: 'Test Code'}})
-      expect(medicationDischarge.frequency()).toEqual new cql.Code('1234', 'SNOMED-CT', '', 'Test Code')
+      medicationDischarge = new CQL_QDM.MedicationDischarge(medicationDischargeEntry)
+      expect(medicationDischarge.frequency()).toEqual new cql.Code('10725009', 'SNOMED-CT')
 
     it "should return an integer of the number of refills", ->
-      medicationDischarge = new CQL_QDM.MedicationDispensed({'start_time': '08/31/2017 1:00 AM', 'end_time': '08/31/2017 2:00 AM', 'refills': {unit: '', scalar: 5}})
-      expect(medicationDischarge.refills()).toEqual 5
+      medicationDischarge = new CQL_QDM.MedicationDischarge(medicationDischargeEntry)
+      expect(medicationDischarge.refills()).toEqual '100'
       
     it "should return a dosage quantity", ->
-      medicationDischarge = new CQL_QDM.MedicationDispensed({'dose': {unit: 'g', scalar: 10}})
-      expect(medicationDischarge.dosage()).toEqual new cql.Quantity({unit: 'g', value: 10})
+      medicationDischarge = new CQL_QDM.MedicationDischarge(medicationDischargeEntry)
+      expect(medicationDischarge.dosage()).toEqual new cql.Quantity({unit: 'mg', value: 100})
+
+    it "should return a negation rationale code", ->
+      medicationDischarge = new CQL_QDM.MedicationDischarge(medicationDischargeEntry)
+      expect(medicationDischarge.negationRationale()).toEqual new cql.Code('29463-7', 'LOINC')
+
+    it "should return a route code", ->
+      medicationDischarge = new CQL_QDM.MedicationDischarge(medicationDischargeEntry)
+      expect(medicationDischarge.route()).toEqual new cql.Code('995218', 'RxNorm')
+
+    it "should return an integer of the number of refills", ->
+      medicationDispensed = new CQL_QDM.MedicationDischarge(medicationDischargeEntry)
+      expect(medicationDispensed.refills()).toEqual '100'
 
     it "should return null when field is not on constructing entry", ->
       medicationDischarge = new CQL_QDM.MedicationDischarge({'start_time': '08/31/2017 1:00 AM', 'end_time': '08/31/2017 2:00 AM'})
@@ -149,3 +421,5 @@ describe "Medication", ->
       expect(medicationDischarge.supply()).toEqual null
       expect(medicationDischarge.dosage()).toEqual null
       expect(medicationDischarge.refills()).toEqual null
+      expect(medicationDischarge.route()).toEqual null
+      expect(medicationDischarge.negationRationale()).toEqual null

--- a/spec/javascripts/datatypes/substance_spec.js.coffee
+++ b/spec/javascripts/datatypes/substance_spec.js.coffee
@@ -1,5 +1,102 @@
 describe "Substance", ->
   describe "Administered", ->
+    substanceAdministeredEntry = {
+      "_id":"5afefb8608fa185cd1c70f3e",
+      "active_datetime":null,
+      "administrationTiming":{"code_system":"RxNorm","code":"1002293","title":"Common substances for allergy and intolerance documentation"},
+      "allowedAdministrations":null,
+      "anatomical_approach":null,
+      "codes":{"RxNorm":["1002293"],"SNOMED-CT":["102259006"]},
+      "cumulativeMedicationDuration":null,
+      "deliveryMethod":null,
+      "description":"Substance, Administered: Common substances for allergy and intolerance documentation",
+      "dose":{"scalar":"25","units":"mg"},
+      "doseIndicator":null,
+      "doseRestriction":null,
+      "end_time":null,
+      "freeTextSig":null,
+      "fulfillmentHistory":[],
+      "fulfillmentInstructions":null,
+      "health_record_field":null,
+      "indication":null,
+      "method":null,
+      "mood_code":"EVN",
+      "negationInd":true,
+      "negationReason":{"code_system":"CDC Race","code":"1002-5"},
+      "oid":"2.16.840.1.113883.3.560.1.164",
+      "patientInstructions":null,
+      "productForm":null,
+      "reaction":null,
+      "reason":null,
+      "refills":null,
+      "route":{"code_system":"RxNorm","code":"995218","title":"Hydroxyzine"},
+      "signed_datetime":null,
+      "specifics":null,
+      "start_time":1337328000,
+      "statusOfMedication":null,
+      "status_code":{"HL7 ActStatus":["administered"]},
+      "supply":{"scalar":"60","units":"mg"},
+      "time":null,
+      "typeOfMedication":null,
+      "vehicle":null
+      }
+
+    it "should return an author DateTime", ->
+      substanceAdministered = new CQL_QDM.SubstanceAdministered(substanceAdministeredEntry)
+      expect(substanceAdministered.authorDatetime()).toEqual new cql.DateTime(2012, 5, 18, 8, 0, 0, 0, 0)
+
+    it "should return null authorDateTime when no is start_time is specified", ->
+      substanceAdministered = new CQL_QDM.SubstanceAdministered({})
+      expect(substanceAdministered.authorDatetime()).toEqual null
+
+    it "should return a dosage quantity", ->
+      substanceAdministered = new CQL_QDM.SubstanceAdministered(substanceAdministeredEntry)
+      expect(substanceAdministered.dosage()).toEqual new cql.Quantity({unit: 'mg', value: '25'})
+
+    it "should return null if no dosage is specified", ->
+      substanceAdministered = new CQL_QDM.SubstanceAdministered({})
+      expect(substanceAdministered.dosage()).toEqual null
+
+    it "should return a frequency code", ->
+      substanceAdministered = new CQL_QDM.SubstanceAdministered(substanceAdministeredEntry)
+      expect(substanceAdministered.frequency()).toEqual new cql.Code('1002293','RxNorm', undefined, 'Common substances for allergy and intolerance documentation')
+
+    it "should return a frequency code", ->
+      substanceAdministered = new CQL_QDM.SubstanceAdministered({})
+      expect(substanceAdministered.frequency()).toEqual null
+
+    it "should return a negationRationale code", ->
+      substanceAdministered = new CQL_QDM.SubstanceAdministered(substanceAdministeredEntry)
+      expect(substanceAdministered.negationRationale()).toEqual new cql.Code('1002-5','CDC Race')
+
+    it "should return a negationRationale code", ->
+      substanceAdministered = new CQL_QDM.SubstanceAdministered({})
+      expect(substanceAdministered.negationRationale()).toEqual null
+
+    it "should return a relevantPeriod interval", ->
+      substanceAdministered = new CQL_QDM.SubstanceAdministered(substanceAdministeredEntry)
+      expect(substanceAdministered.relevantPeriod()).toEqual new cql.Interval(new cql.DateTime(2012,5,18,8,0,0,0,0), new cql.DateTime(9999,12,31,23,59,59,999,0))
+
+    it "should return null if no relevantPeriod is specified", ->
+      substanceAdministered = new CQL_QDM.SubstanceAdministered({})
+      expect(substanceAdministered.relevantPeriod()).toEqual null
+
+    it "should return a route code", ->
+      substanceAdministered = new CQL_QDM.SubstanceAdministered(substanceAdministeredEntry)
+      expect(substanceAdministered.route()).toEqual new cql.Code('995218', 'RxNorm')
+
+    it "should return null if no route is specified", ->
+      substanceAdministered = new CQL_QDM.SubstanceAdministered({})
+      expect(substanceAdministered.route()).toEqual null
+
+    it "should return a supply quantity", ->
+      substanceAdministered = new CQL_QDM.SubstanceAdministered(substanceAdministeredEntry)
+      expect(substanceAdministered.supply()).toEqual new cql.Quantity(unit: 'mg', value: '60')
+
+    it "should return null if no supply is specified", ->
+      substanceAdministered = new CQL_QDM.SubstanceAdministered({})
+      expect(substanceAdministered.supply()).toEqual null
+
     it "should show null relevantPeriod", ->
       substanceAdministered = new CQL_QDM.SubstanceAdministered({})
       expect(substanceAdministered.relevantPeriod()).toBeNull()
@@ -12,10 +109,6 @@ describe "Substance", ->
       substanceAdministered = new CQL_QDM.SubstanceAdministered({'administrationTiming': {code: '1234', code_system: 'SNOMED-CT', version: '', title: 'Test Code'}})
       expect(substanceAdministered.frequency()).toEqual new cql.Code('1234', 'SNOMED-CT', '', 'Test Code')
 
-    it "should return a dosage quantity", ->
-      substanceAdministered = new CQL_QDM.SubstanceAdministered({'dose': {unit: 'g', scalar: 10}})
-      expect(substanceAdministered.dosage()).toEqual new cql.Quantity({unit: 'g', value: 10})
-
     it "should return null when field is not on constructing entry", ->
       substanceAdministered = new CQL_QDM.SubstanceAdministered({'start_time': '08/31/2017 1:00 AM', 'end_time': '08/31/2017 2:00 AM'})
       expect(substanceAdministered.frequency()).toEqual null
@@ -23,6 +116,120 @@ describe "Substance", ->
       expect(substanceAdministered.dosage()).toEqual null
 
   describe "Order", ->
+    substanceOrderEntry = {
+      "_id":"5aff087b08fa185cd1c70f6d",
+      "active_datetime":null,
+      "administrationTiming":{"code_system":"RxNorm","code":"1010600","title":"Opioid Pain Medications"},
+      "allowedAdministrations":null,
+      "anatomical_approach":null,
+      "codes":{"NCI Thesaurus":["C26659"]},
+      "cumulativeMedicationDuration":null,
+      "deliveryMethod":null,
+      "description":"Substance, Order: Marijuana",
+      "dose":{"scalar":"25","units":"mg"},
+      "doseIndicator":null,
+      "doseRestriction":null,
+      "end_time":null,
+      "freeTextSig":null,
+      "fulfillmentHistory":[],
+      "fulfillmentInstructions":null,
+      "health_record_field":null,
+      "indication":null,
+      "method":null,
+      "mood_code":"EVN",
+      "negationInd":true,
+      "negationReason":{"code_system":"LOINC","code":"29463-7"},
+      "oid":"2.16.840.1.113883.3.560.1.168",
+      "patientInstructions":null,
+      "productForm":null,
+      "reaction":null,
+      "reason":{"code_system":"RxNorm","code":"1010600","title":"Opioid Pain Medications"},
+      "refills":{"scalar":"10","units":"mg"},
+      "route":{"code_system":"RxNorm","code":"1002293","title":"Common substances for allergy and intolerance documentation"},
+      "signed_datetime":null,
+      "specifics":null,
+      "start_time":1337328000,
+      "statusOfMedication":null,
+      "status_code":{"HL7 ActStatus":["ordered"]},
+      "supply":{"scalar":"60","units":"mg"},
+      "time":null,
+      "typeOfMedication":null,
+      "vehicle":null
+      }
+
+    it "should return an author DateTime", ->
+      substanceOrder = new CQL_QDM.SubstanceOrder(substanceOrderEntry)
+      expect(substanceOrder.authorDatetime()).toEqual new cql.DateTime(2012, 5, 18, 8, 0, 0, 0, 0)
+
+    it "should return null authorDateTime when no is start_time is specified", ->
+      substanceOrder = new CQL_QDM.SubstanceOrder({})
+      expect(substanceOrder.authorDatetime()).toEqual null
+
+    it "should return a dosage quantity", ->
+      substanceOrder = new CQL_QDM.SubstanceOrder(substanceOrderEntry)
+      expect(substanceOrder.dosage()).toEqual new cql.Quantity({unit: 'mg', value: '25'})
+
+    it "should return null if no dosage is specified", ->
+      substanceOrder = new CQL_QDM.SubstanceOrder({})
+      expect(substanceOrder.dosage()).toEqual null
+
+    it "should return a frequency code", ->
+      substanceOrder = new CQL_QDM.SubstanceOrder(substanceOrderEntry)
+      expect(substanceOrder.frequency()).toEqual new cql.Code('1010600','RxNorm', undefined, 'Opioid Pain Medications')
+
+    it "should return a frequency code", ->
+      substanceOrder = new CQL_QDM.SubstanceOrder({})
+      expect(substanceOrder.frequency()).toEqual null
+
+    # TODO: Method is missing from Substance.js.coffee
+    # it "should return a method Code", ->
+    #    laboratoryTestPerformed = new CQL_QDM.LaboratoryTestPerformed(laboratoryTestPerformedEntry)
+    #    expect(laboratoryTestPerformed.method()).toEqual 'something'
+
+    it "should return null if no method is specified", ->
+       substanceOrder = new CQL_QDM.SubstanceOrder({})
+       expect(substanceOrder.method()).toEqual null
+
+    it "should return a negationRationale code", ->
+      substanceOrder = new CQL_QDM.SubstanceOrder(substanceOrderEntry)
+      expect(substanceOrder.negationRationale()).toEqual new cql.Code('29463-7','LOINC')
+
+    it "should return a negationRationale code", ->
+      substanceOrder = new CQL_QDM.SubstanceOrder({})
+      expect(substanceOrder.negationRationale()).toEqual null
+
+    it "should return a reason code", ->
+      substanceOrder = new CQL_QDM.SubstanceOrder(substanceOrderEntry)
+      expect(substanceOrder.reason()).toEqual new cql.Code('1010600', 'RxNorm')
+
+    it "should return null if no reason is specified", ->
+      substanceOrder = new CQL_QDM.SubstanceOrder({})
+      expect(substanceOrder.reason()).toEqual null
+
+    it "should a refills scalar", ->
+      substanceOrder = new CQL_QDM.SubstanceOrder(substanceOrderEntry)
+      expect(substanceOrder.refills()).toEqual '10'
+
+    it "should return null if no refills is specified", ->
+      substanceOrder = new CQL_QDM.SubstanceOrder({})
+      expect(substanceOrder.refills()).toEqual null
+
+    it "should return a route code", ->
+      substanceOrder = new CQL_QDM.SubstanceOrder(substanceOrderEntry)
+      expect(substanceOrder.route()).toEqual new cql.Code('1002293', 'RxNorm')
+
+    it "should return null if no route is specified", ->
+      substanceOrder = new CQL_QDM.SubstanceOrder({})
+      expect(substanceOrder.route()).toEqual null
+
+    it "should return a supply quantity", ->
+      substanceOrder = new CQL_QDM.SubstanceOrder(substanceOrderEntry)
+      expect(substanceOrder.supply()).toEqual new cql.Quantity(unit: 'mg', value: '60')
+
+    it "should return null if no supply is specified", ->
+      substanceOrder = new CQL_QDM.SubstanceOrder({})
+      expect(substanceOrder.supply()).toEqual null
+
     it "should return an integer of the number of refills", ->
       substanceOrder = new CQL_QDM.SubstanceOrder({'start_time': '08/31/2017 1:00 AM', 'end_time': '08/31/2017 2:00 AM', 'refills': {unit: '', scalar: 5}})
       expect(substanceOrder.refills()).toEqual 5
@@ -32,7 +239,7 @@ describe "Substance", ->
       expect(substanceOrder.frequency()).toEqual new cql.Code('1234', 'SNOMED-CT', '', 'Test Code')
 
     it "should return a dosage quantity", ->
-      substanceOrder = new CQL_QDM.SubstanceOrder({'dose': {unit: 'g', scalar: 10}})
+      substanceOrder = new CQL_QDM.SubstanceOrder({'dose': {units: 'g', scalar: 10}})
       expect(substanceOrder.dosage()).toEqual new cql.Quantity({unit: 'g', value: 10})
 
     it "should return null when field is not on constructing entry", ->
@@ -43,6 +250,120 @@ describe "Substance", ->
       expect(substanceOrder.dosage()).toEqual null
 
   describe "Recommended", ->
+    substanceRecommendedEntry = {
+      "_id":"5aff0e1108fa185cd1c70f98",
+      "active_datetime":null,
+      "administrationTiming":{"code_system":"SNOMED-CT","code":"10725009","title":"Essential Hypertension"},
+      "allowedAdministrations":null,
+      "anatomical_approach":null,
+      "codes":{},
+      "cumulativeMedicationDuration":null,
+      "deliveryMethod":null,
+      "description":"Substance, Recommended: Substance, Recommended",
+      "dose":{"scalar":"50","units":"mg"},
+      "doseIndicator":null,
+      "doseRestriction":null,
+      "end_time":null,
+      "freeTextSig":null,
+      "fulfillmentHistory":[],
+      "fulfillmentInstructions":null,
+      "health_record_field":null,
+      "indication":null,
+      "method":null,
+      "mood_code":"EVN",
+      "negationInd":true,
+      "negationReason":{"code_system":"CDC Race","code":"1002-5"},
+      "oid":"2.16.840.1.113883.3.560.1.193",
+      "patientInstructions":null,
+      "productForm":null,
+      "reaction":null,
+      "reason":{"code_system":"RxNorm","code":"995218","title":"Hydroxyzine"},
+      "refills":{"scalar":"10","units":""},
+      "route":{"code_system":"SNOMED-CT","code":"10725009","title":"Essential Hypertension"},
+      "signed_datetime":null,
+      "specifics":null,
+      "start_time":1337328000,
+      "statusOfMedication":null,
+      "status_code":{"HL7 ActStatus":["recommended"]},
+      "supply":{"scalar":"60","units":"mg"},
+      "time":null,
+      "typeOfMedication":null,
+      "vehicle":null
+      }
+
+    it "should return an author DateTime", ->
+      substanceRecommended = new CQL_QDM.SubstanceRecommended(substanceRecommendedEntry)
+      expect(substanceRecommended.authorDatetime()).toEqual new cql.DateTime(2012, 5, 18, 8, 0, 0, 0, 0)
+
+    it "should return null authorDateTime when no is start_time is specified", ->
+      substanceRecommended = new CQL_QDM.SubstanceRecommended({})
+      expect(substanceRecommended.authorDatetime()).toEqual null
+
+    it "should return a dosage quantity", ->
+      substanceRecommended = new CQL_QDM.SubstanceRecommended(substanceRecommendedEntry)
+      expect(substanceRecommended.dosage()).toEqual new cql.Quantity({unit: 'mg', value: '50'})
+
+    it "should return null if no dosage is specified", ->
+      substanceRecommended = new CQL_QDM.SubstanceRecommended({})
+      expect(substanceRecommended.dosage()).toEqual null
+
+    it "should return a frequency code", ->
+      substanceRecommended = new CQL_QDM.SubstanceRecommended(substanceRecommendedEntry)
+      expect(substanceRecommended.frequency()).toEqual new cql.Code('10725009','SNOMED-CT', undefined, 'Essential Hypertension')
+
+    it "should return a frequency code", ->
+      substanceRecommended = new CQL_QDM.SubstanceRecommended({})
+      expect(substanceRecommended.frequency()).toEqual null
+
+    # TODO: Method is missing from Substance.js.coffee
+    # it "should return a method Code", ->
+    #    substanceRecommended = new CQL_QDM.SubstanceRecommended(substanceRecommendedEntry)
+    #    expect(substanceRecommended.method()).toEqual 'something'
+
+    it "should return null if no method is specified", ->
+       substanceRecommended = new CQL_QDM.SubstanceRecommended({})
+       expect(substanceRecommended.method()).toEqual null
+
+    it "should return a negationRationale code", ->
+      substanceRecommended = new CQL_QDM.SubstanceRecommended(substanceRecommendedEntry)
+      expect(substanceRecommended.negationRationale()).toEqual new cql.Code('1002-5','CDC Race')
+
+    it "should return a negationRationale code", ->
+      substanceRecommended = new CQL_QDM.SubstanceRecommended({})
+      expect(substanceRecommended.negationRationale()).toEqual null
+
+    it "should return a reason code", ->
+      substanceRecommended = new CQL_QDM.SubstanceRecommended(substanceRecommendedEntry)
+      expect(substanceRecommended.reason()).toEqual new cql.Code('995218', 'RxNorm')
+
+    it "should return null if no reason is specified", ->
+      substanceRecommended = new CQL_QDM.SubstanceRecommended({})
+      expect(substanceRecommended.reason()).toEqual null
+
+    it "should a refills scalar", ->
+      substanceRecommended = new CQL_QDM.SubstanceRecommended(substanceRecommendedEntry)
+      expect(substanceRecommended.refills()).toEqual '10'
+
+    it "should return null if no refills is specified", ->
+      substanceRecommended = new CQL_QDM.SubstanceRecommended({})
+      expect(substanceRecommended.refills()).toEqual null
+
+    it "should return a route code", ->
+      substanceRecommended = new CQL_QDM.SubstanceRecommended(substanceRecommendedEntry)
+      expect(substanceRecommended.route()).toEqual new cql.Code('10725009', 'SNOMED-CT')
+
+    it "should return null if no route is specified", ->
+      substanceRecommended = new CQL_QDM.SubstanceRecommended({})
+      expect(substanceRecommended.route()).toEqual null
+
+    it "should return a supply quantity", ->
+      substanceRecommended = new CQL_QDM.SubstanceRecommended(substanceRecommendedEntry)
+      expect(substanceRecommended.supply()).toEqual new cql.Quantity(unit: 'mg', value: '60')
+
+    it "should return null if no supply is specified", ->
+      substanceRecommended = new CQL_QDM.SubstanceRecommended({})
+      expect(substanceRecommended.supply()).toEqual null
+
     it "should return an integer of the number of refills", ->
       substanceRecommended = new CQL_QDM.SubstanceRecommended({'start_time': '08/31/2017 1:00 AM', 'end_time': '08/31/2017 2:00 AM', 'refills': {unit: '', scalar: 5}})
       expect(substanceRecommended.refills()).toEqual 5
@@ -52,7 +373,7 @@ describe "Substance", ->
       expect(substanceRecommended.frequency()).toEqual new cql.Code('1234', 'SNOMED-CT', '', 'Test Code')
 
     it "should return a dosage quantity", ->
-      substanceRecommended = new CQL_QDM.SubstanceRecommended({'dose': {unit: 'g', scalar: 10}})
+      substanceRecommended = new CQL_QDM.SubstanceRecommended({'dose': {units: 'g', scalar: 10}})
       expect(substanceRecommended.dosage()).toEqual new cql.Quantity({unit: 'g', value: 10})
 
     it "should return null when field is not on constructing entry", ->

--- a/spec/javascripts/datatypes/substance_spec.js.coffee
+++ b/spec/javascripts/datatypes/substance_spec.js.coffee
@@ -182,9 +182,9 @@ describe "Substance", ->
       expect(substanceOrder.frequency()).toEqual null
 
     # TODO: Method is missing from Substance.js.coffee
-    # it "should return a method Code", ->
-    #    laboratoryTestPerformed = new CQL_QDM.LaboratoryTestPerformed(laboratoryTestPerformedEntry)
-    #    expect(laboratoryTestPerformed.method()).toEqual 'something'
+    xit "should return a method Code", ->
+       laboratoryTestPerformed = new CQL_QDM.LaboratoryTestPerformed(laboratoryTestPerformedEntry)
+       expect(laboratoryTestPerformed.method()).toEqual 'something'
 
     it "should return null if no method is specified", ->
        substanceOrder = new CQL_QDM.SubstanceOrder({})
@@ -316,9 +316,9 @@ describe "Substance", ->
       expect(substanceRecommended.frequency()).toEqual null
 
     # TODO: Method is missing from Substance.js.coffee
-    # it "should return a method Code", ->
-    #    substanceRecommended = new CQL_QDM.SubstanceRecommended(substanceRecommendedEntry)
-    #    expect(substanceRecommended.method()).toEqual 'something'
+    xit "should return a method Code", ->
+       substanceRecommended = new CQL_QDM.SubstanceRecommended(substanceRecommendedEntry)
+       expect(substanceRecommended.method()).toEqual 'something'
 
     it "should return null if no method is specified", ->
        substanceRecommended = new CQL_QDM.SubstanceRecommended({})


### PR DESCRIPTION
Change unit->units in several data criteria types to match data coming from patient_builder.rb in bonnie. Add tests that use entry data coming from patient_builder in bonnie grabbed in the console during the initialization of the data criteria.

Pull requests into CQL QDM Patient API require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] JIRA ticket for this PR: https://jira.mitre.org/browse/BONNIE-1503
- [x] JIRA ticket links to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Code coverage has not gone down and all code touched or added is covered.
    * In rare situations, this may not be possible or applicable to a PR. In those situations:
        1. Note why this could not be done or is not applicable here:
        2. Add TODOs in the code noting that it requires a test
        3. Add a JIRA task to add the test and link it here:
- [x] Automated regression test(s) pass One regression on the MPR account, dosage units were not seen before, now that they are an invalid UCUM unit 'mcg' error is thrown

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA test links: NA
- [x] Justification for using JIRA tests: NA
- [x] JIRA tests have been added to sprint NA


**Reviewer 1:**

Name: @losborne
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA tests have been run and pass N/A
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree N/A


**Reviewer 2:**

Name: @hossenlopp
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests: N/A
- [x] JIRA tests have been run and pass N/A
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree N/A
