### PR TITLE
Updated cql_qdm_patientapi for 1.1.3 release.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cql_qdm_patientapi (1.1.2)
+    cql_qdm_patientapi (1.1.3)
       coffee-rails (~> 4.1)
       rails (~> 4.2)
       sprockets-rails (~> 2.3)

--- a/lib/cql_qdm_patientapi/version.rb
+++ b/lib/cql_qdm_patientapi/version.rb
@@ -1,3 +1,3 @@
 module CqlQdmPatientapi
-  VERSION = "1.1.2"
+  VERSION = "1.1.3"
 end


### PR DESCRIPTION
Pull requests into CQL QDM Patient API require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)

**Reviewer 1:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] You have tried to break the code
