### PR TITLE
Updated cql_qdm_patientapi for 1.1.4 release.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cql_qdm_patientapi (1.1.3)
+    cql_qdm_patientapi (1.1.4)
       coffee-rails (~> 4.1)
       rails (~> 4.2)
       sprockets-rails (~> 2.3)
@@ -128,4 +128,4 @@ DEPENDENCIES
   teaspoon-jasmine (= 2.3.4)
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/lib/cql_qdm_patientapi/version.rb
+++ b/lib/cql_qdm_patientapi/version.rb
@@ -1,3 +1,3 @@
 module CqlQdmPatientapi
-  VERSION = "1.1.3"
+  VERSION = "1.1.4"
 end


### PR DESCRIPTION
Gem version update.
Pull requests into CQL QDM Patient API require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] JIRA ticket for this PR: N/A
- [x] JIRA ticket links to this PR N/A
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] Tests are included and test edge cases N/A
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Code coverage has not gone down and all code touched or added is covered. N/A
- [x] Automated regression test(s) pass N/A

If JIRA tests were used to supplement or replace automated tests:
- [x] JIRA test links: N/A
- [x] Justification for using JIRA tests: N/A
- [x] JIRA tests have been added to sprint N/A


**Reviewer 1:**

Name:
- [ ] Gemfile.lock sanity check

