### PR TITLE
Removed `supply` attribute from QDM types that no longer have it

### DIFF
--- a/app/assets/javascripts/datatypes/immunization.js.coffee
+++ b/app/assets/javascripts/datatypes/immunization.js.coffee
@@ -21,7 +21,6 @@ class CQL_QDM.ImmunizationAdministered extends CQL_QDM.QDMDatatype
     @_negationRationale = @entry.negationReason
     @_reason = @entry.reason
     @_route = @entry.route
-    @_supply = @entry.supply
     delete @entry.end_time
 
   ###
@@ -69,14 +68,6 @@ class CQL_QDM.ImmunizationAdministered extends CQL_QDM.QDMDatatype
     else
       null
 
-  ###
-  @returns {Quantity}
-  ###
-  supply: ->
-    if @_supply?
-      new cql.Quantity({unit: @_supply['units'], value: @_supply['scalar']})
-    else
-      null
 
 
 ###

--- a/app/assets/javascripts/datatypes/medication.js.coffee
+++ b/app/assets/javascripts/datatypes/medication.js.coffee
@@ -27,7 +27,6 @@ class CQL_QDM.MedicationActive extends CQL_QDM.QDMDatatype
     else
       # No end time; high is set to infinity
       @_relevantPeriodHigh = CQL_QDM.Helpers.infinityDateTime()
-    @_supply = @entry.supply
 
   ###
   @returns {Quantity}
@@ -70,15 +69,6 @@ class CQL_QDM.MedicationActive extends CQL_QDM.QDMDatatype
     else
       null
 
-  ###
-  @returns {Quantity}
-  ###
-  supply: ->
-    if @_supply?
-      new cql.Quantity({unit: @_supply['units'], value: @_supply['scalar']})
-    else
-      null
-
 
 ###
 Data elements that meet criteria using this datatype should document that the
@@ -103,7 +93,6 @@ class CQL_QDM.MedicationAdministered extends CQL_QDM.QDMDatatype
       # No end time; high is set to infinity
       @_relevantPeriodHigh = CQL_QDM.Helpers.infinityDateTime()
     @_route = @entry.route
-    @_supply = @entry.supply
 
   ###
   Author date time is only present when this data type has been negated.
@@ -168,15 +157,6 @@ class CQL_QDM.MedicationAdministered extends CQL_QDM.QDMDatatype
   route: ->
     if @_route?
       new cql.Code(@_route.code, @_route.code_system, null, @_route.title || null)
-    else
-      null
-
-  ###
-  @returns {Quantity}
-  ###
-  supply: ->
-    if @_supply?
-      new cql.Quantity({unit: @_supply['units'], value: @_supply['scalar']})
     else
       null
 

--- a/app/assets/javascripts/datatypes/substance.js.coffee
+++ b/app/assets/javascripts/datatypes/substance.js.coffee
@@ -27,7 +27,6 @@ class CQL_QDM.SubstanceAdministered extends CQL_QDM.QDMDatatype
       # No end time; high is set to infinity
       @_relevantPeriodHigh = CQL_QDM.Helpers.infinityDateTime()
     @_route = @entry.route
-    @_supply = @entry.supply
 
   ###
   Author date time is only present when this data type has been negated.
@@ -86,14 +85,6 @@ class CQL_QDM.SubstanceAdministered extends CQL_QDM.QDMDatatype
     else
       null
 
-  ###
-  @returns {Quantity}
-  ###
-  supply: ->
-    if @_supply?
-      new cql.Quantity({unit: @_supply['units'], value: @_supply['scalar']})
-    else
-      null
 
 
 ###
@@ -218,7 +209,6 @@ class CQL_QDM.SubstanceRecommended extends CQL_QDM.QDMDatatype
     @_reason = @entry.reason
     @_refills = @entry.refills
     @_route = @entry.route
-    @_supply = @entry.supply
     delete @entry.end_time
 
   ###
@@ -290,14 +280,5 @@ class CQL_QDM.SubstanceRecommended extends CQL_QDM.QDMDatatype
   route: ->
     if @_route?
       new cql.Code(@_route.code, @_route.code_system, null, @_route.title || null)
-    else
-      null
-
-  ###
-  @returns {Quantity}
-  ###
-  supply: ->
-    if @_supply?
-      new cql.Quantity({unit: @_supply['units'], value: @_supply['scalar']})
     else
       null

--- a/spec/javascripts/datatypes/immunization_spec.js.coffee
+++ b/spec/javascripts/datatypes/immunization_spec.js.coffee
@@ -34,7 +34,6 @@ describe "Immunization", ->
         "start_time":1337155200,
         "statusOfMedication":null,
         "status_code":{"HL7 ActStatus":["administered"]},
-        "supply":{"scalar":"14","units":"mg"},
         "time":null,
         "typeOfMedication":null,
         "vehicle":null
@@ -79,14 +78,6 @@ describe "Immunization", ->
     it "should return null if no route is specified", ->
       immunizationAdministered = new CQL_QDM.ImmunizationAdministered({})
       expect(immunizationAdministered.route()).toEqual null
-
-    it "should return a supply quantity", ->
-      immunizationAdministered = new CQL_QDM.ImmunizationAdministered(immunizationAdministeredEntry)
-      expect(immunizationAdministered.supply()).toEqual new cql.Quantity({unit: 'mg', value: '14'})
-
-    it "should return null if no supply is specified", ->
-      immunizationAdministered = new CQL_QDM.ImmunizationAdministered({})
-      expect(immunizationAdministered.supply()).toEqual null
 
   describe "Order", ->
     immunizationOrderedEntry = {

--- a/spec/javascripts/datatypes/immunization_spec.js.coffee
+++ b/spec/javascripts/datatypes/immunization_spec.js.coffee
@@ -34,6 +34,7 @@ describe "Immunization", ->
         "start_time":1337155200,
         "statusOfMedication":null,
         "status_code":{"HL7 ActStatus":["administered"]},
+        "supply":{"scalar":"14","units":"mg"},
         "time":null,
         "typeOfMedication":null,
         "vehicle":null

--- a/spec/javascripts/datatypes/medication_spec.js.coffee
+++ b/spec/javascripts/datatypes/medication_spec.js.coffee
@@ -233,6 +233,7 @@ describe "Medication", ->
       "start_time":1337846400,
       "statusOfMedication":null,
       "status_code":{"SNOMED-CT":["55561003"],"HL7 ActStatus":["active"]},
+      "supply":{"scalar":"1000","units":"g"},
       "time":null,
       "typeOfMedication":null,
       "vehicle":null
@@ -301,6 +302,7 @@ describe "Medication", ->
       "start_time":1337673600,
       "statusOfMedication":null,
       "status_code":{"HL7 ActStatus":["administered"]},
+      "supply":{"scalar":"44","units":"mg"},
       "time":null,
       "typeOfMedication":null,
       "vehicle":null

--- a/spec/javascripts/datatypes/medication_spec.js.coffee
+++ b/spec/javascripts/datatypes/medication_spec.js.coffee
@@ -233,7 +233,6 @@ describe "Medication", ->
       "start_time":1337846400,
       "statusOfMedication":null,
       "status_code":{"SNOMED-CT":["55561003"],"HL7 ActStatus":["active"]},
-      "supply":{"scalar":"1000","units":"g"},
       "time":null,
       "typeOfMedication":null,
       "vehicle":null
@@ -259,15 +258,10 @@ describe "Medication", ->
       medicationActive = new CQL_QDM.MedicationActive(medicationActiveEntry)
       expect(medicationActive.route()).toEqual new cql.Code('995218', 'RxNorm', null, 'Hydroxyzine')
 
-    it "should return a supply quantity", ->
-      medicationActive = new CQL_QDM.MedicationActive(medicationActiveEntry)
-      expect(medicationActive.supply()).toEqual new cql.Quantity({unit: 'g', value: '1000'})
-
     it "should return null when field is not on constructing entry", ->
       medicationActive = new CQL_QDM.MedicationActive({'start_time': '08/31/2017 1:00 AM', 'end_time': '08/31/2017 2:00 AM'})
       expect(medicationActive.frequency()).toEqual null
       expect(medicationActive.dosage()).toEqual null
-      expect(medicationActive.supply()).toEqual null
 
   describe "Administered", ->
     medicationAdministeredEntry ={
@@ -307,7 +301,6 @@ describe "Medication", ->
       "start_time":1337673600,
       "statusOfMedication":null,
       "status_code":{"HL7 ActStatus":["administered"]},
-      "supply":{"scalar":"44","units":"mg"},
       "time":null,
       "typeOfMedication":null,
       "vehicle":null
@@ -341,14 +334,9 @@ describe "Medication", ->
       medicationAdministered = new CQL_QDM.MedicationAdministered(medicationAdministeredEntry)
       expect(medicationAdministered.route()).toEqual new cql.Code('1002293', 'RxNorm', null, 'Common substances for allergy and intolerance documentation')
 
-    it "should return a supply quantity", ->
-      medicationAdministered = new CQL_QDM.MedicationAdministered(medicationAdministeredEntry)
-      expect(medicationAdministered.supply()).toEqual new cql.Quantity({unit: 'mg', value: '44'})
-
     it "should return null when field is not on constructing entry", ->
       medicationAdministered = new CQL_QDM.MedicationAdministered({'start_time': '08/31/2017 1:00 AM', 'end_time': '08/31/2017 2:00 AM'})
       expect(medicationAdministered.frequency()).toEqual null
-      expect(medicationAdministered.supply()).toEqual null
       expect(medicationAdministered.dosage()).toEqual null
       expect(medicationAdministered.route()).toEqual null
       expect(medicationAdministered.reason()).toEqual null

--- a/spec/javascripts/datatypes/substance_spec.js.coffee
+++ b/spec/javascripts/datatypes/substance_spec.js.coffee
@@ -35,6 +35,7 @@ describe "Substance", ->
       "start_time":1337328000,
       "statusOfMedication":null,
       "status_code":{"HL7 ActStatus":["administered"]},
+      "supply":{"scalar":"60","units":"mg"},
       "time":null,
       "typeOfMedication":null,
       "vehicle":null
@@ -274,6 +275,7 @@ describe "Substance", ->
       "start_time":1337328000,
       "statusOfMedication":null,
       "status_code":{"HL7 ActStatus":["recommended"]},
+      "supply":{"scalar":"60","units":"mg"},
       "time":null,
       "typeOfMedication":null,
       "vehicle":null

--- a/spec/javascripts/datatypes/substance_spec.js.coffee
+++ b/spec/javascripts/datatypes/substance_spec.js.coffee
@@ -35,7 +35,6 @@ describe "Substance", ->
       "start_time":1337328000,
       "statusOfMedication":null,
       "status_code":{"HL7 ActStatus":["administered"]},
-      "supply":{"scalar":"60","units":"mg"},
       "time":null,
       "typeOfMedication":null,
       "vehicle":null
@@ -89,14 +88,6 @@ describe "Substance", ->
       substanceAdministered = new CQL_QDM.SubstanceAdministered({})
       expect(substanceAdministered.route()).toEqual null
 
-    it "should return a supply quantity", ->
-      substanceAdministered = new CQL_QDM.SubstanceAdministered(substanceAdministeredEntry)
-      expect(substanceAdministered.supply()).toEqual new cql.Quantity(unit: 'mg', value: '60')
-
-    it "should return null if no supply is specified", ->
-      substanceAdministered = new CQL_QDM.SubstanceAdministered({})
-      expect(substanceAdministered.supply()).toEqual null
-
     it "should show null relevantPeriod", ->
       substanceAdministered = new CQL_QDM.SubstanceAdministered({})
       expect(substanceAdministered.relevantPeriod()).toBeNull()
@@ -112,7 +103,6 @@ describe "Substance", ->
     it "should return null when field is not on constructing entry", ->
       substanceAdministered = new CQL_QDM.SubstanceAdministered({'start_time': '08/31/2017 1:00 AM', 'end_time': '08/31/2017 2:00 AM'})
       expect(substanceAdministered.frequency()).toEqual null
-      expect(substanceAdministered.supply()).toEqual null
       expect(substanceAdministered.dosage()).toEqual null
 
   describe "Order", ->
@@ -284,7 +274,6 @@ describe "Substance", ->
       "start_time":1337328000,
       "statusOfMedication":null,
       "status_code":{"HL7 ActStatus":["recommended"]},
-      "supply":{"scalar":"60","units":"mg"},
       "time":null,
       "typeOfMedication":null,
       "vehicle":null
@@ -354,14 +343,6 @@ describe "Substance", ->
       substanceRecommended = new CQL_QDM.SubstanceRecommended({})
       expect(substanceRecommended.route()).toEqual null
 
-    it "should return a supply quantity", ->
-      substanceRecommended = new CQL_QDM.SubstanceRecommended(substanceRecommendedEntry)
-      expect(substanceRecommended.supply()).toEqual new cql.Quantity(unit: 'mg', value: '60')
-
-    it "should return null if no supply is specified", ->
-      substanceRecommended = new CQL_QDM.SubstanceRecommended({})
-      expect(substanceRecommended.supply()).toEqual null
-
     it "should return an integer of the number of refills", ->
       substanceRecommended = new CQL_QDM.SubstanceRecommended({'start_time': '08/31/2017 1:00 AM', 'end_time': '08/31/2017 2:00 AM', 'refills': {unit: '', scalar: 5}})
       expect(substanceRecommended.refills()).toEqual 5
@@ -378,6 +359,5 @@ describe "Substance", ->
       substanceRecommended = new CQL_QDM.SubstanceRecommended({'start_time': '08/31/2017 1:00 AM', 'end_time': '08/31/2017 2:00 AM'})
       expect(substanceRecommended.frequency()).toEqual null
       expect(substanceRecommended.refills()).toEqual null
-      expect(substanceRecommended.supply()).toEqual null
       expect(substanceRecommended.dosage()).toEqual null
       expect(substanceRecommended.entry.end_time).toEqual undefined


### PR DESCRIPTION
The following types had `supply` removed in 5.4:

- Medication, Active
- Medication, Administered
- Substance, Administered
- Substance, Recommended
- Immunization, Administered

The following types have retained `supply` attribute:

- Medication, Discharge
- Medication, Dispensed
- Immunization, Order
- Medication, Order
- Substance, Order

Pull requests into CQL QDM Patient API require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] JIRA ticket for this PR: https://jira.mitre.org/browse/BONNIE-1602 https://jira.mitre.org/browse/BONNIE-1659
- [x] JIRA ticket links to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Code coverage has not gone down and all code touched or added is covered.
    * In rare situations, this may not be possible or applicable to a PR. In those situations:
        1. Note why this could not be done or is not applicable here: Drop in coverage percentage due to code being removed.
        2. Add TODOs in the code noting that it requires a test N/A
        3. Add a JIRA task to add the test and link it here: N/A
- [x] Automated regression test(s) pass

If JIRA tests were used to supplement or replace automated tests: N/A
- [x] JIRA test links: N/A
- [x] Justification for using JIRA tests: N/A
- [x] JIRA tests have been added to sprint


**Reviewer 1:**

Name: @edeyoung 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests: N/A
- [x] JIRA tests have been run and pass
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree


**Reviewer 2:**

Name: @losborne
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests: N/A
- [x] JIRA tests have been run and pass
- [x] You agree with the justification for use of JIRA tests or have provided input on why you disagree
