### PR TITLE
modify toString to support CODE for arbitrary PatientCharactersitics

### DIFF
--- a/app/assets/javascripts/datatypes/datatype.js.coffee
+++ b/app/assets/javascripts/datatypes/datatype.js.coffee
@@ -74,8 +74,8 @@ class CQL_QDM.QDMDatatype
     startTime = if @entry?.start_time then "START: #{moment.utc(@entry.start_time, 'X').format('MM/DD/YYYY h:mm A')}\n" else ""
     endTime = if @entry?.end_time then "STOP: #{moment.utc(@entry.end_time, 'X').format('MM/DD/YYYY h:mm A')}\n" else ""
     # TODO: Refactor getCode()/code() so that this special logic is not necessary.
-    # If it is a patient characteristic (other than payer), use getCode() instead of code()
-    if /PatientCharacteristic/.test(this.constructor.name) and this.constructor.name != 'PatientCharacteristicPayer'
+    # These PatientCharacteristics use getCode instead of code.  Others still use code.
+    if /PatientCharacteristic(?:Ethnicity|Expired|Race|Sex)/.test(this.constructor.name)
       code = @getCode()
     else if @_codes
       # Get code if this datatype has any

--- a/spec/javascripts/datatypes/patient_charactersitic_spec.js.coffee
+++ b/spec/javascripts/datatypes/patient_charactersitic_spec.js.coffee
@@ -1,0 +1,31 @@
+patientCharacteristicMaleEntry = {
+  _id :"5aeb774bb848463d625b2991",
+  anatomical_location :null,
+  anatomical_target :null,
+  causeOfDeath :null,
+  codes :{"AdministrativeGender":["M"]},
+  description :"Patient Characteristic: Male",
+  end_time :null,
+  health_record_field :null,
+  laterality :null,
+  mood_code :"EVN",
+  name :null,
+  negationInd :null,
+  negationReason :null,
+  oid :"2.16.840.1.113883.3.560.1.1001",
+  ordinality :null,
+  priority :null,
+  reason :null,
+  severity :null,
+  specifics :null,
+  start_time :-674150400,
+  status_code :{"HL7 ActStatus":[null]},
+  time :null,
+  time_of_death :null,
+  type :null
+  }
+
+describe "Patient Characteristic Male", ->
+  it 'should have CODE in toString', ->
+    patientCharacteristicRace = new CQL_QDM.PatientCharacteristic(patientCharacteristicMaleEntry)
+    expect(patientCharacteristicRace.toString()).toEqual 'Patient Characteristic: Male\nSTART: 08/21/1948 8:00 AM\nCODE: AdministrativeGender M'

--- a/spec/javascripts/datatypes/patient_charactersitic_spec.js.coffee
+++ b/spec/javascripts/datatypes/patient_charactersitic_spec.js.coffee
@@ -27,5 +27,5 @@ patientCharacteristicMaleEntry = {
 
 describe "Patient Characteristic Male", ->
   it 'should have CODE in toString', ->
-    patientCharacteristicRace = new CQL_QDM.PatientCharacteristic(patientCharacteristicMaleEntry)
-    expect(patientCharacteristicRace.toString()).toEqual 'Patient Characteristic: Male\nSTART: 08/21/1948 8:00 AM\nCODE: AdministrativeGender M'
+    patientCharacteristicMale = new CQL_QDM.PatientCharacteristic(patientCharacteristicMaleEntry)
+    expect(patientCharacteristicMale.toString()).toEqual 'Patient Characteristic: Male\nSTART: 08/21/1948 8:00 AM\nCODE: AdministrativeGender M'


### PR DESCRIPTION
PatientCharactersiticMale revealed a gap in the `toString` function that would improperly treat `PatientCharacteristic`s that were not one of the special cases that use `getCode`.  This PR addresses that, which will get rid of some of the frontend/backend export diffs (Turns out this one is just cosmetic.)

Pull requests into CQL QDM Patient API require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] This PR is into the correct branch.
- [x] JIRA ticket for this PR: https://jira.mitre.org/browse/BONNIE-1675
- [x] JIRA ticket links to this PR
- [x] Code diff has been done and been reviewed (it **does not** contain: additional white space, not applicable code changes, debug statements, etc.)
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass (remember to update Gemfile when applicable)
- [x] Code coverage has not gone down and all code touched or added is covered.
(new regex added a couple of branches that are not tested, but overall more coverage)
branch | coverage
-- | --
bonnie-v3.0 | Statements   : 75.43% ( 1630/2161 )<br>Branches     : 50% ( 521/1042 )<br>Functions    : 67.02% ( 313/467 )<br>Lines        : 73.65% ( 1406/1909 )
fix_patient_charactersitic_male | Statements   : 75.61% ( 1634/2161 ) <br>Branches     : 49.9% ( 519/1040 )<br>Functions    : 67.24% ( 314/467 )<br>Lines        : 73.86% ( 1410/1909 )
- [x] Automated regression test(s) pass N/A only toString affected

If JIRA tests were used to supplement or replace automated tests:
- ~[x] JIRA test links:~
- ~[x] Justification for using JIRA tests:~
- ~[x] JIRA tests have been added to sprint~


**Reviewer 1:**

Name: @jbradl11 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- ~[x] JIRA tests have been run and pass~
- ~[x] You agree with the justification for use of JIRA tests or have provided input on why you disagree~


**Reviewer 2:**

Name: @mayerm94 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

If JIRA tests were used to supplement or replace automated tests:
- ~[x] JIRA tests have been run and pass~
- ~[x] You agree with the justification for use of JIRA tests or have provided input on why you disagree~
